### PR TITLE
Add csp lib

### DIFF
--- a/app/Policies/CspPolicy.php
+++ b/app/Policies/CspPolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policies\Basic;
+
+class CspPolicy extends Basic
+{
+    public function configure()
+    {
+        parent::configure();
+
+        if (app()->environment() === 'local') {
+            /*
+            Resources to use
+            https://github.com/vitejs/vite/issues/11862
+            https://github.com/spatie/laravel-csp/discussions/101
+            https://laracasts.com/discuss/channels/laravel/how-to-set-content-security-policy-for-laravel-bundle-assets
+            https://laracasts.com/discuss/channels/vite/laravel-vite-with-laravel-valet-on-local-network
+            https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
+
+            */
+
+            $this
+                ->addDirective(Directive::BASE, 'localhost:*')
+                ->addDirective(Directive::CONNECT, 'localhost:*')
+                ->addDirective(Directive::CONNECT, 'ws://localhost:*') /* websocket */
+                ->addDirective(Directive::DEFAULT, 'localhost:*')
+                ->addDirective(Directive::IMG, 'localhost:*')
+                ->addDirective(Directive::MEDIA, 'localhost:*')
+                ->addDirective(Directive::OBJECT, 'localhost:*')
+                ->addDirective(Directive::SCRIPT, 'localhost:*')
+                ->addDirective(Directive::STYLE, 'localhost:*')
+                ->addDirective(Directive::IMG, 'www.placeholder.com')
+                ->addDirective(Directive::IMG, 'via.placeholder.com')
+                ->addDirective(Directive::IMG, 'placehold.it');
+        }
+
+        // $this
+        //     ->addDirective(Directive::CONNECT, Scheme::WSS)
+        //     ->addDirective(Directive::IMG, Scheme::DATA);
+
+        $this->addDirective(Directive::STYLE, 'unsafe-inline');
+        $this->removeDirective(Directive::STYLE, 'nonce-', 'starts_with');
+        $this->addDirective(Directive::DEFAULT, 'fonts.bunny.net');
+        $this->addDirective(Directive::STYLE, 'fonts.bunny.net');
+        $this->addDirective(Directive::SCRIPT, 'https://unpkg.com/lucide@latest');
+        $this->addDirective(Directive::SCRIPT, 'https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js');
+        $this->addDirective(Directive::IMG, 'data:');
+    }
+}

--- a/app/Support/ViteNonceGenerator.php
+++ b/app/Support/ViteNonceGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Support;
+
+
+use Illuminate\Support\Facades\Vite;
+use Spatie\Csp\Nonce\NonceGenerator;
+
+class ViteNonceGenerator implements NonceGenerator
+{
+    public function generate(): string
+    {
+        return Vite::useCspNonce();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,12 +6,13 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: __DIR__ . '/../routes/web.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
         //
+        $middleware->append(\Spatie\Csp\AddCspHeaders::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.9",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9",
+        "spatie/laravel-csp": "^2.10"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e8c3c14ff33b199b4a0838993eb8423",
+    "content-hash": "6d9a7bb26c976975ab3b9e8df806d991",
     "packages": [
         {
             "name": "brick/math",
@@ -3108,6 +3108,148 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "spatie/laravel-csp",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-csp.git",
+                "reference": "116caa57ece29969aebb5fd64e6f5500169218c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-csp/zipball/116caa57ece29969aebb5fd64e6f5500169218c6",
+                "reference": "116caa57ece29969aebb5fd64e6f5500169218c6",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^9.0|^10.0|^11.0",
+                "illuminate/support": "^9.0|^10.0|^11.0",
+                "php": "^8.1",
+                "spatie/laravel-package-tools": "^1.11"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^7.0|^8.0|^9.0",
+                "pestphp/pest": "^1.23.0|^2.34.0",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Csp\\CspServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Csp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Verhelst",
+                    "email": "tvke91@gmail.com",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Add CSP headers to the responses of a Laravel app",
+            "homepage": "https://github.com/spatie/laravel-csp",
+            "keywords": [
+                "content-security-policy",
+                "csp",
+                "headers",
+                "laravel",
+                "laravel-csp",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/laravel-csp/tree/2.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-06-04T11:27:13+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.16.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "ddf678e78d7f8b17e5cdd99c0c3413a4a6592e53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/ddf678e78d7f8b17e5cdd99c0c3413a4a6592e53",
+                "reference": "ddf678e78d7f8b17e5cdd99c0c3413a4a6592e53",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.28|^10.0|^11.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^7.7|^8.0",
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^9.5.24",
+                "spatie/pest-plugin-test-time": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.16.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-20T07:29:11+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/csp.php
+++ b/config/csp.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+     * A policy will determine which CSP headers will be set. A valid CSP policy is
+     * any class that extends `Spatie\Csp\Policies\Policy`
+     */
+    'policy' =>  App\Policies\CspPolicy::class,
+
+    /*
+     * This policy which will be put in report only mode. This is great for testing out
+     * a new policy or changes to existing csp policy without breaking anything.
+     */
+    'report_only_policy' => '',
+
+    /*
+     * All violations against the policy will be reported to this url.
+     * A great service you could use for this is https://report-uri.com/
+     *
+     * You can override this setting by calling `reportTo` on your policy.
+     */
+    'report_uri' => env('CSP_REPORT_URI', ''),
+
+    /*
+     * Headers will only be added if this setting is set to true.
+     */
+    'enabled' => env('CSP_ENABLED', true),
+
+    /*
+     * The class responsible for generating the nonces used in inline tags and headers.
+     */
+    'nonce_generator' => App\Support\ViteNonceGenerator::class,
+];

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,10 +8,16 @@ export default defineConfig({
                 'resources/js/app.js',
                 'resources/js/index.js',
                 'resources/js/employee/dashboard.js',
-                'vendor/node_modules/bootstrap/dist/js/bootstrap.min.js',
-
+                'node_modules/bootstrap/dist/js/bootstrap.min.js',
             ],
             refresh: true,
         }),
     ],
+    server: {
+        host: process.env.APP_URL,
+        hmr: {
+            host: 'localhost',
+        },
+    },
+
 });


### PR DESCRIPTION
_This  an optional library_ #2 
- _This only adds security to prevent unauthorized scrips style external images etc. to be executed_
- _This can be rejected if unwanted_
- I also still use vite with `npm run dev `to host my assets
- May need to run  **  `composer update`  ** as I only see composer.json is the only file update when running `composer require spatie/laravel-csp
`


---
### Aftermath
Now that the csp is enforced unregistered scripts or style src and internal scripts without correct hash signature will blocked.
![image](https://github.com/user-attachments/assets/d7121d49-b826-47a8-b4ff-1b27807df2f2)

![Screenshot 2024-08-14 101029](https://github.com/user-attachments/assets/098273cd-4c58-4914-a92a-e6d0afbc08e5)

### Registering
Here is an example registries of authorized scripts
![image](https://github.com/user-attachments/assets/dcbe55c9-8c3a-486d-b47f-ff3803a5cebd)

### Adding Hash
Hash can be inserted on internal scripts and styles
https://github.com/spatie/laravel-csp?tab=readme-ov-file#usage:~:text=Next%20you%20must%20add%20the%20nonce%20to%20the%20html%3A
{{-- in a view --}}
```
<style nonce="{{ csp_nonce() }}">
   ...
</style>
```

```
<script nonce="{{ csp_nonce() }}">
   ...
</script>
```
