### PR TITLE
chore(model/migration): office names and heads

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -90,6 +90,12 @@ class Employee extends Model
         return $this->hasOne(SpecificArea::class, 'area_manager', 'employee_id');
     }
 
+    // returns the office where employee is office head
+    public function officeHeadOf(): HasOne
+    {
+        return $this->hasOne(Office::class, 'office_head', 'employee_id');
+    }
+
     // returns the shift schedule of employee
     public function shift(): BelongsTo
     {

--- a/app/Models/Office.php
+++ b/app/Models/Office.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Office extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'office_id';
+
+    protected $guarded = [
+        'office_id',
+        'created_at',
+        'updated_at',
+    ];
+
+    // returns the employee who's the office head
+    public function head(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'office_head', 'employee_id');
+    }
+}

--- a/database/migrations/2024_09_21_080257_create_offices_table.php
+++ b/database/migrations/2024_09_21_080257_create_offices_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Employee;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('offices', function (Blueprint $table) {
+            $table->id('office_id');
+            $table->string('office_name', 100);
+            $table->longText('office_desc')->nullable();
+
+            $table->foreignIdFor(Employee::class, 'office_head')
+                ->nullable()
+                ->constrained('employees', 'employee_id')
+                ->cascadeOnUpdate()
+                ->nullOnDelete();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('offices');
+    }
+};


### PR DESCRIPTION
## Chore

- Create a migration file for office names and define relationships with employee who will assume as office head.
- Example use case:
   - An office named Accounting Office was created, the office should have an office head and it should be one of its employees.
   - I made the office_head fk constraint nullable and I don't know if that was correct. Perhaps, I was thinking a situation where the employee records have been removed. And if that's the case, it doesn't seem right to cascade the office name too.