### PR TITLE
chore(models/migrations): employee and applicant's records lifecycle

### DIFF
--- a/app/Models/Applicant.php
+++ b/app/Models/Applicant.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Applicant extends Model
 {
@@ -35,5 +36,17 @@ class Applicant extends Model
     public function application(): HasOne
     {
         return $this->hasOne(Application::class, 'applicant_id', 'applicant_id');
+    }
+
+    // returns applicants's permanent barangay address
+    public function permanentBarangay(): BelongsTo
+    {
+        return $this->belongsTo(Barangay::class, 'permanent_barangay', 'barangay_code');
+    }
+
+    // returns applicant's present barangay address
+    public function presentBarangay(): BelongsTo
+    {
+        return $this->belongsTo(Barangay::class, 'present_barangay', 'barangay_code');
     }
 }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -12,6 +12,8 @@ class Application extends Model
 {
     use HasFactory;
 
+    public $timestamps = false;
+
     protected $primaryKey = 'application_id';
 
     protected $guarded = [
@@ -31,6 +33,12 @@ class Application extends Model
     {
         return $this->belongsTo(Applicant::class, 'applicant_id', 'applicant_id');
     }
+
+    // returns employee's application records
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'application_id', 'employee_id');
+    }    
 
     // returns submitted documents of the application
     public function documents(): HasMany

--- a/app/Models/Barangay.php
+++ b/app/Models/Barangay.php
@@ -23,14 +23,26 @@ class Barangay extends Model
     */
 
     // returns employees who are permanent barangay residents
-    public function permanentResidents(): HasMany
+    public function permanentEmployeeResidents(): HasMany
     {
         return $this->hasMany(Employee::class, 'permanent_barangay', 'barangay_code');
     }
 
+    // returns applicants who are permanent barangay residents
+    public function permanentApplicantResidents(): HasMany
+    {
+        return $this->hasMany(Applicant::class, 'permanent_barangay', 'barangay_code');
+    }
+
     // returns employees who are present barangay residents
-    public function presentResidents(): HasMany
+    public function presentEmployeeResidents(): HasMany
     {
         return $this->hasMany(Employee::class, 'present_barangay', 'barangay_code');
+    }
+
+    // returns applicants who are present barangay residents
+    public function presentApplicantResidents(): HasMany
+    {
+        return $this->hasMany(Applicant::class, 'present_barangay', 'barangay_code');
     }
 }

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -35,6 +35,12 @@ class Employee extends Model
         return $this->morphOne(User::class, 'account');
     }
 
+    // returns employee's application records
+    public function application(): HasOne
+    {
+        return $this->hasOne(Application::class, 'application_id', 'employee_id');
+    }
+
     // returns employment status of employee
     public function employmentStatus(): BelongsTo
     {

--- a/app/Models/Guest.php
+++ b/app/Models/Guest.php
@@ -13,6 +13,7 @@ class Guest extends Model
     protected $primaryKey = 'guest_id';
 
     protected $guarded = [
+        'guest_id',
         'created_at',
         'updated_at',
     ];

--- a/database/factories/ApplicantFactory.php
+++ b/database/factories/ApplicantFactory.php
@@ -43,6 +43,13 @@ class ApplicantFactory extends Factory
             'middle_name' => fake()->firstName,
             'last_name' => fake()->lastName,
             'contact_number' => fake()->unique()->numerify('###########'),
+            'sex' => fake()->randomElement(['MALE', 'FEMALE']),
+            'civil_status' => fake()->randomElement(['SINGLE', 'MARRIED', 'WIDOWED', 'LEGALLY SEPARATED']),
+            'present_barangay' => fake()->randomElement(['0102801001', '0102802001']),
+            'permanent_barangay' => fake()->randomElement(['0102802002', '0102802003']),
+            'present_address' => fake()->address,
+            'permanent_address' => fake()->address,
+            'date_of_birth' => fake()->date,
             'education' => json_encode($education),
             'experience' => json_encode($experience),
         ];

--- a/database/factories/ApplicationFactory.php
+++ b/database/factories/ApplicationFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Applicant;
+use App\Models\JobVacancy;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Application>
+ */
+class ApplicationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'applicant_id' => Applicant::factory(),
+            'job_vacancy_id' => JobVacancy::factory(),
+            'application_status_id' => 2, // approved or hired
+            'hired_at' => now(),
+        ];
+    }
+}

--- a/database/factories/CompanyDocFactory.php
+++ b/database/factories/CompanyDocFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Document>
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CompanyDoc>
  */
 class CompanyDocFactory extends Factory
 {

--- a/database/factories/EmployeeFactory.php
+++ b/database/factories/EmployeeFactory.php
@@ -2,8 +2,9 @@
 
 namespace Database\Factories;
 
-use App\Models\EmploymentStatus;
 use App\Models\JobDetail;
+use App\Models\Application;
+use App\Models\EmploymentStatus;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -18,18 +19,40 @@ class EmployeeFactory extends Factory
      */
     public function definition(): array
     {
+        $educationCount = fake()->numberBetween(1, 3); // Random count between 1 and 5
+        $experienceCount = fake()->numberBetween(1, 5); // Random count between 1 and 5
+
+        $education = [];
+        for ($i = 0; $i < $educationCount; $i++) {
+            $education[] = [
+                'degree' => fake()->word,
+                'institution' => fake()->company,
+                'year' => fake()->year,
+            ];
+        }
+
+        $experience = [];
+        for ($i = 0; $i < $experienceCount; $i++) {
+            $experience[] = [
+                'company' => fake()->company,
+                'position' => fake()->jobTitle,
+                'years' => fake()->numberBetween(1, 10),
+            ];
+        }
+
         return [
             'first_name' => fake()->firstName,
             'middle_name' => fake()->firstName,
             'last_name' => fake()->lastName,
+            'application_id' => Application::factory(),
             'job_detail_id' => JobDetail::factory(),
-            'hired_at' => fake()->dateTimeThisDecade,
             'emp_status_id' => EmploymentStatus::factory(),
             'present_barangay' => fake()->randomElement(['0102801001', '0102802001']),
             'permanent_barangay' => fake()->randomElement(['0102802002', '0102802003']),
             'present_address' => fake()->address,
             'permanent_address' => fake()->address,
             'contact_number' => fake()->unique()->numerify('###########'),
+            'date_of_birth' => fake()->date,
             'sex' => fake()->randomElement(['MALE', 'FEMALE']),
             'civil_status' => fake()->randomElement(['SINGLE', 'MARRIED', 'WIDOWED', 'LEGALLY SEPARATED']),
             'sss_no' => fake()->numerify('##########'),
@@ -37,7 +60,8 @@ class EmployeeFactory extends Factory
             'tin_no' => fake()->numerify('############'),
             'pag_ibig_no' => fake()->numerify('############'),
             'signature' => fake()->sha256,
-            'education' => fake()->word,
+            'education' => json_encode($education),
+            'experience' => json_encode($experience),
         ];
     }
 }

--- a/database/factories/GuestFactory.php
+++ b/database/factories/GuestFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Guest>
+ */
+class GuestFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'first_name' => fake()->firstName(),
+            'middle_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
+        ];
+    }
+}

--- a/database/migrations/2024_09_03_113157_create_employees_table.php
+++ b/database/migrations/2024_09_03_113157_create_employees_table.php
@@ -1,12 +1,13 @@
 <?php
 
 use App\Models\Employee;
-use App\Models\EmploymentStatus;
 use App\Models\JobDetail;
+use App\Models\Application;
 use App\Models\LeaveCategory;
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
+use App\Models\EmploymentStatus;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration
 {
@@ -33,37 +34,34 @@ return new class extends Migration
                 ->cascadeOnUpdate()
                 ->cascadeOnDelete();
 
-            $table->timestamp('hired_at');
-
             $table->foreignIdFor(EmploymentStatus::class, 'emp_status_id')
                 ->constrained('employment_statuses', 'emp_status_id')
                 ->cascadeOnUpdate()
                 ->restrictOnDelete();
 
+            $table->longText('present_address');
             $table->string('present_barangay', 10);
-
             $table->foreign('present_barangay')
                 ->references('barangay_code')->on('barangays')
                 ->onDelete('cascade');
 
-            $table->longText('present_address');
+            $table->longText('permanent_address');         
             $table->string('permanent_barangay', 10);
-
             $table->foreign('permanent_barangay')
                 ->references('barangay_code')->on('barangays')
                 ->onDelete('cascade');
 
-            $table->longText('permanent_address');
-
             $table->string('contact_number', 11)->unique();
             $table->enum('sex', ['MALE', 'FEMALE']);
             $table->enum('civil_status', ['SINGLE', 'MARRIED', 'WIDOWED', 'LEGALLY SEPARATED']);
+            $table->date('date_of_birth')->nullable();
             $table->string('sss_no', 10)->unique();
             $table->string('philhealth_no', 12)->unique();
             $table->string('tin_no', 12)->unique();
             $table->string('pag_ibig_no', 12)->unique();
             $table->binary('signature');
-            $table->string('education');
+            $table->jsonb('education')->nullable();
+            $table->jsonb('experience')->nullable();
             $table->integer('leave_balance')->default(0);
             $table->timestamps();
         });

--- a/database/migrations/2024_09_03_113158_create_applicants_table.php
+++ b/database/migrations/2024_09_03_113158_create_applicants_table.php
@@ -16,7 +16,23 @@ return new class extends Migration
             $table->string('first_name');
             $table->string('middle_name')->nullable();
             $table->string('last_name');
+
+            $table->longText('present_address');
+            $table->string('present_barangay', 10);
+            $table->foreign('present_barangay')
+                ->references('barangay_code')->on('barangays')
+                ->onDelete('cascade');
+
+            $table->longText('permanent_address');
+            $table->string('permanent_barangay', 10);
+            $table->foreign('permanent_barangay')
+                ->references('barangay_code')->on('barangays')
+                ->onDelete('cascade');
+
             $table->string('contact_number', 11)->index();
+            $table->enum('sex', ['MALE', 'FEMALE']);
+            $table->enum('civil_status', ['SINGLE', 'MARRIED', 'WIDOWED', 'LEGALLY SEPARATED']);
+            $table->date('date_of_birth')->nullable();
             $table->jsonb('education')->nullable();
             $table->jsonb('experience')->nullable();
             $table->timestamps();

--- a/database/migrations/2024_09_03_113160_create_applications_table.php
+++ b/database/migrations/2024_09_03_113160_create_applications_table.php
@@ -44,7 +44,7 @@ return new class extends Migration
                 ->cascadeOnUpdate()
                 ->cascadeOnDelete();
 
-            $table->timestamps();
+            $table->timestamp('hired_at')->nullable();
         });
 
         Schema::create('application_docs', function (Blueprint $table) {

--- a/database/migrations/2024_10_18_045749_add_application_id_to_employees_table.php
+++ b/database/migrations/2024_10_18_045749_add_application_id_to_employees_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Application;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            // will be used to retrieved the employee's hired date
+            $table->foreignIdFor(Application::class, 'application_id')
+                ->constrained('applications', 'application_id')
+                ->cascadeOnUpdate()
+                ->restrictOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropForeignIdFor(Application::class, 'application_id');
+        });
+    }
+};

--- a/database/migrations/2024_10_18_045749_add_application_id_to_employees_table.php
+++ b/database/migrations/2024_10_18_045749_add_application_id_to_employees_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
         Schema::table('employees', function (Blueprint $table) {
             // will be used to retrieved the employee's hired date
             $table->foreignIdFor(Application::class, 'application_id')
+                ->nullable()
                 ->constrained('applications', 'application_id')
                 ->cascadeOnUpdate()
                 ->restrictOnDelete();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,6 +34,8 @@ class DatabaseSeeder extends Seeder
 
         $this->call(UserStatusSeeder::class);
 
+        $this->call(ApplicationStatusSeeder::class);
+
         $this->call(RolesAndPermissionsSeeder::class);
 
         $this->call(PsgcSeeder::class);
@@ -100,8 +102,6 @@ class DatabaseSeeder extends Seeder
         JobVacancy::factory(25)->create();
 
         $this->call(PreempRequirementSeeder::class);
-
-        $this->call(ApplicationStatusSeeder::class);
 
         Application::create([
             'applicant_id' => $applicant->applicant_id,


### PR DESCRIPTION
### 🛠 Changes

- I removed the `hired_at` column in the `employees` and moved it to the `applications` table instead.
- I defined the missing attributes of `barangay` and `present_address` in the `applicants` table, as well as the model relationships between `Barangay` and `Applicant`
- I added a new foreign id `application_id` to the `employees` table.
- I added the `guest_id` attribute to $guarded fields of the `Guest` model to forbid mass assignment.
- I created new factory files to seed the database.

### 🧠 Rationale

- The `hired_at` column was moved because it belongs to the `applications` since we are tracking an applicant's application so it shouldn't be placed in the `employees` table.
- The address of the applicants was also overlooked when I was defining its attributes.
- For the audit trail of an employee's lifecycle, we should be able to link an employee to his application history. Those who were employees before the web app's implementation will be an exception here.

### 🦶 Steps

- Run `php artisan migrate:fresh --seed` to recreate and seed the database tables.

### ✔️ Checklist

- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
