### PR TITLE
Chore/session fix

### DIFF
--- a/app/Events/UserLoggedout.php
+++ b/app/Events/UserLoggedout.php
@@ -13,14 +13,14 @@ class UserLoggedout implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    protected $auth_broadcast_id;
+    protected $authBroadcastId;
 
     /**
      * Create a new event instance.
      */
-    public function __construct($auth_broadcast_id)
+    public function __construct($authBroadcastId)
     {
-        $this->auth_broadcast_id = $auth_broadcast_id;
+        $this->authBroadcastId = $authBroadcastId;
     }
 
     /**
@@ -34,13 +34,13 @@ class UserLoggedout implements ShouldBroadcastNow
         //     new PrivateChannel('channel-name'),
         // ];
 
-        return new PrivateChannel('user_auth.'.$this->auth_broadcast_id);
+        return new PrivateChannel('user_auth.' . $this->authBroadcastId);
     }
 
     public function broadcastWith()
     {
         return [
-            'auth_broadcast_id' => $this->auth_broadcast_id,
+            'authBroadcastId' => $this->authBroadcastId,
         ];
     }
 }

--- a/app/Http/Controllers/Employee/DashboardController.php
+++ b/app/Http/Controllers/Employee/DashboardController.php
@@ -14,7 +14,7 @@ class DashboardController extends Controller
     {
         $guard = Auth::guard('employee');
 
-        $authenticated_user = Cache::flexible('user_' . $guard->id(), [30, 60], function () use ($guard) {
+        $user = Cache::flexible('user_' . $guard->id(), [30, 60], function () use ($guard) {
             return User::where('user_id', $guard->id())
                 ->with(['roles', 'account'])
                 ->get()
@@ -22,7 +22,7 @@ class DashboardController extends Controller
         });
 
         $dashboard = match (true) {
-            $authenticated_user->hasRole(UserRole::INTERMEDIATE->value) => 'employee.hr-manager.index',
+            $user->hasRole(UserRole::INTERMEDIATE->value) => 'employee.hr-manager.index',
                 // HR
 
                 // Superviser

--- a/app/Http/Helpers/ChooseGuard.php
+++ b/app/Http/Helpers/ChooseGuard.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Str;
 
 class ChooseGuard
 {
-    public static function getByReferrer(): string
+    public static function getByReferrer(?Request $request = null): string
     {
-        $request_referer = request()->headers->get('referer');
-        $referrer = parse_url($request_referer, PHP_URL_PATH);
+        $request = $request ?? request();
+        $requestReferer = $request->headers->get('referer');
+        $referrer = parse_url($requestReferer, PHP_URL_PATH);
 
         return match (true) {
             Str::is('/employee/*', $referrer) => 'employee',
@@ -19,7 +20,7 @@ class ChooseGuard
         };
     }
 
-    public static function getByRequest(?Request $request = null): string
+    public static function getByRequest(?Request  $request = null): string
     {
         $request = $request ?? request();
 

--- a/app/Http/Middleware/SetDynamicGuard.php
+++ b/app/Http/Middleware/SetDynamicGuard.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Helpers\ChooseGuard;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetDynamicGuard
+{
+    /**
+     * Checks incoming request and choose appropriate guard.
+     *
+     * Uses referer to determine the guard.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // This could handle the guard switching e.g. livewire/update requests
+        $guard = ChooseGuard::getByReferrer($request);
+        if ($guard) Auth::shouldUse($guard);
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Auth/Logout.php
+++ b/app/Livewire/Auth/Logout.php
@@ -11,7 +11,7 @@ class Logout extends Component
 {
     protected $class;
 
-    protected $auth_broadcast_id;
+    protected $authBroadcastId;
 
     protected $nonce;
 
@@ -26,7 +26,7 @@ class Logout extends Component
         $this->use_guard = ChooseGuard::getByRequest();
 
         $user_session = session()->getId();
-        $this->auth_broadcast_id = hash('sha512', $user_session.Auth::guard($this->use_guard)->user()->email.$user_session);
+        $this->authBroadcastId = hash('sha512', $user_session . Auth::guard($this->use_guard)->user()->email . $user_session);
     }
 
     public function render()
@@ -35,7 +35,7 @@ class Logout extends Component
         return <<<'HTML'
         <form action="/{{ $this->use_guard }}/logout" method="POST" nonce="{{ $this->nonce }}">
             @csrf
-            <input type="hidden" name="auth_broadcast_id" value="{{$this->auth_broadcast_id}}">
+            <input type="hidden" name="authBroadcastId" value="{{$this->authBroadcastId}}">
             <button type="submit"  nonce="{{ $this->nonce }}" class="{{$this->class}}">
                 Logout
             </button>

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use App\Models\User;
 use App\Enums\UserRole;
 use Laravel\Pulse\Facades\Pulse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Facades\Storage;
@@ -66,10 +65,10 @@ class AppServiceProvider extends ServiceProvider
 
         /**
          * Store strings representing the models.
-         * 
-         * Instead of inserting import names of App\Models\ModelName in the column_type, we 
+         *
+         * Instead of inserting import names of App\Models\ModelName in the column_type, we
          * can store strings representing the model (e.g.: 'guest' => 'App\Models\Guest').
-         * 
+         *
          * @see https://laravel.com/docs/11.x/eloquent-relationships#custom-polymorphic-types
          */
         Relation::enforceMorphMap([
@@ -92,10 +91,10 @@ class AppServiceProvider extends ServiceProvider
          * - making requests
          * - experiencing slow endpoints
          * - dispatching jobs
-         * 
+         *
          * @see https://laravel.com/docs/11.x/pulse#dashboard-resolving-users
          */
-        Pulse::user(fn ($user) => [
+        Pulse::user(fn($user) => [
             'name' => $user->account->full_name,
             'extra' => $user->email,
             'avatar' => $user->photo ?? Storage::url('icons/default-avatar.png'),
@@ -103,10 +102,10 @@ class AppServiceProvider extends ServiceProvider
 
         /**
          * This will only allow user with advanced role to access the pulse dashboard.
-         * 
+         *
          * @see https://laravel.com/docs/11.x/pulse#dashboard-authorization
          */
-        Gate::define('viewPulse', function(User $user) {
+        Gate::define('viewPulse', function (User $user) {
             return $user->hasRole(UserRole::ADVANCED);
         });
     }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -158,13 +158,13 @@ class FortifyServiceProvider extends ServiceProvider
 
             // Loop through all guards and check which one has authenticated user then use that guard
             foreach (GuardType::values() as $guardType) {
-                $currentUser = Auth::guard($guardType)->user();
+                $isAuthenticated = Auth::guard($guardType)->check();
 
-                if ($currentUser) {
+                if ($isAuthenticated) {
                     $guard = $guardType;
                     $view = "$guard.dashboard";
 
-                    /*TODO Add check if guest or applicant */
+                    /*TODO If web add check if guest or applicant? */
 
                     return redirect()->route($view);
                     break;

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -157,15 +157,14 @@ class FortifyServiceProvider extends ServiceProvider
             $guard = null;
 
             // Loop through all guards and check which one has authenticated user then use that guard
-            foreach (GuardType::values() as $guardType) {
+            $guards = GuardType::values();
+            for ($i = 0; $i < count($guards); $i++) {
+                $guardType = $guards[$i];
                 $isAuthenticated = Auth::guard($guardType)->check();
-
                 if ($isAuthenticated) {
                     $guard = $guardType;
                     $view = "$guard.dashboard";
-
                     /*TODO If web add check if guest or applicant? */
-
                     return redirect()->route($view);
                     break;
                 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -64,7 +64,7 @@ class FortifyServiceProvider extends ServiceProvider
             public function toResponse($request)
             {
                 try {
-                    broadcast(new UserLoggedout($request->auth_broadcast_id))->toOthers();
+                    broadcast(new UserLoggedout($request->authBroadcastId))->toOthers();
                 } catch (\Throwable $th) {
                     // avoid Pusher error: cURL error 7: Failed to connect to localhost port 8080 after 2209 ms: Couldn't connect to server
                     /* when websocket server is not started */
@@ -78,59 +78,59 @@ class FortifyServiceProvider extends ServiceProvider
         {
             public function toResponse($request)
             {
-                $authenticated_user = Auth::guard(ChooseGuard::getByReferrer())->user();
+                $user = Auth::guard(ChooseGuard::getByReferrer())->user();
 
-                $user_with_role_and_account = User::where('user_id', $authenticated_user->user_id)
+                $userWithRoleAndAccount = User::where('user_id', $user->user_id)
                     ->with(['roles'])
                     ->first();
 
                 // Redirection to previously visited page before being prompt to login
                 // For example you visit /employee/payslip and you are not logged in
                 // Instead of redirecting to dashboard after successful login you will be redirected to /employee/payslip
-                $intended_url = Session::get('url.intended');
+                $intendedUrl = Session::get('url.intended');
 
-                if ($intended_url && $authenticated_user) {
-                    $route = Route::getRoutes()->match(Request::create($intended_url));
+                if ($intendedUrl && $user) {
+                    $route = Route::getRoutes()->match(Request::create($intendedUrl));
                     $middleware = $route->gatherMiddleware();
 
-                    $has_access = true;
+                    $hasAccess = true;
 
-                    foreach ($middleware as $middleware_item) {
+                    foreach ($middleware as $middlewareItem) {
 
-                        if (str_contains($middleware_item, 'role:')) {
-                            $role = explode(':', $middleware_item)[1];
-                            if (! $user_with_role_and_account->hasRole($role)) {
-                                $has_access = false;
+                        if (str_contains($middlewareItem, 'role:')) {
+                            $role = explode(':', $middlewareItem)[1];
+                            if (! $userWithRoleAndAccount->hasRole($role)) {
+                                $hasAccess = false;
                                 break;
                             }
                         }
 
-                        if (str_contains($middleware_item, 'permission:')) {
-                            $permission = explode(':', $middleware_item)[1];
-                            if (! $user_with_role_and_account->can($permission)) {
-                                $has_access = false;
+                        if (str_contains($middlewareItem, 'permission:')) {
+                            $permission = explode(':', $middlewareItem)[1];
+                            if (! $userWithRoleAndAccount->can($permission)) {
+                                $hasAccess = false;
                                 break;
                             }
                         }
                     }
 
-                    if ($has_access) {
+                    if ($hasAccess) {
                         return redirect()->intended();
                     }
                 }
 
-                if ($authenticated_user->account_type == AccountType::EMPLOYEE->value) {
+                if ($user->account_type == AccountType::EMPLOYEE->value) {
 
-                    if ($user_with_role_and_account->hasRole(UserRole::ADVANCED->value)) {
+                    if ($userWithRoleAndAccount->hasRole(UserRole::ADVANCED->value)) {
                         return redirect('/admin/dashboard');
                     }
 
-                    if ($user_with_role_and_account->hasRole([UserRole::BASIC->value, UserRole::INTERMEDIATE->value])) {
+                    if ($userWithRoleAndAccount->hasRole([UserRole::BASIC->value, UserRole::INTERMEDIATE->value])) {
                         return redirect('/employee/dashboard');
                     }
                 }
 
-                if ($authenticated_user->account_type == AccountType::APPLICANT->value) {
+                if ($user->account_type == AccountType::APPLICANT->value) {
                     return redirect('/applicant');
                 }
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,8 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Enums\AccountType;
+use App\Enums\GuardType;
+use App\Enums\UserPermission;
 use App\Enums\UserRole;
 use App\Events\UserLoggedout;
 use App\Http\Helpers\ChooseGuard;
@@ -151,6 +153,24 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::verifyEmailView(fn() => app(UnverifiedEmail::class)->render());
 
         Fortify::loginView(function () {
+
+            $guard = null;
+
+            // Loop through all guards and check which one has authenticated user then use that guard
+            foreach (GuardType::values() as $guardType) {
+                $currentUser = Auth::guard($guardType)->user();
+
+                if ($currentUser) {
+                    $guard = $guardType;
+                    $view = "$guard.dashboard";
+
+                    /*TODO Add check if guest or applicant */
+
+                    return redirect()->route($view);
+                    break;
+                }
+            }
+
             $view = match (true) {
                 request()->is('employee/*') => 'livewire.auth.employees.login-view',
                 request()->is('admin/*') => 'livewire.auth.admins.login-view',

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\Localization;
 use App\Http\Middleware\SaveVisitedPage;
+use App\Http\Middleware\SetDynamicGuard;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -34,6 +35,7 @@ return Application::configure(basePath: dirname(__DIR__))
         __DIR__ . '/../routes/channels.php',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->prepend(SetDynamicGuard::class);
         $middleware->append(AddCspHeaders::class);
 
         $middleware->alias([
@@ -45,6 +47,9 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->redirectGuestsTo(function (Request $request) {
+
+
+
             if ($request->is('employee/*')) {
                 return 'employee/login';
             }

--- a/resources/views/components/authenticated-broadcast-id.blade.php
+++ b/resources/views/components/authenticated-broadcast-id.blade.php
@@ -7,11 +7,11 @@
 @php
 if (Auth::guard($use_guard)->check()) {
     $user_session = session()->getId();
-    $auth_broadcast_id = hash('sha512', $user_session . Auth::guard($use_guard)->user()->email . $user_session);
+    $authBroadcastId = hash('sha512', $user_session . Auth::guard($use_guard)->user()->email . $user_session);
 @endphp
 
     @once
-        var AUTH_BROADCAST_ID = "{{ $auth_broadcast_id }}";
+        var AUTH_BROADCAST_ID = "{{ $authBroadcastId }}";
     @endonce
 
 @php

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -6,10 +6,10 @@ Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
 
-Broadcast::channel('user_auth.{user_broadcast_id}', function ($user, string $user_broadcast_id) {
+Broadcast::channel('user_auth.{userBroadcastId}', function ($user, string $userBroadcastId) {
 
     $user_session = session()->getId();
-    $this_auth_broadcast_id = hash('sha512', $user_session.$user->email.$user_session);
+    $thisAuthBroadcastId = hash('sha512', $user_session . $user->email . $user_session);
 
-    return $this_auth_broadcast_id == $user_broadcast_id;
+    return $thisAuthBroadcastId == $userBroadcastId;
 }, ['guards' => ['web', 'employee', 'admin']]);


### PR DESCRIPTION
### 🛠 Changes
Added SetDynamicGuard middleware
Added checking of authenticated guard in Forify LoginView

### ✨ Context
The session user_id is reset to null but upon inspecting who calls Auth class I think livewire/update triggers a request lifecycle causing the session user_id to request due to it using web guard as being the requestURI is livewire/update but existing fortify guard is set by requestURI 

I also came across these sources

- [user_id conflict for multiple guards laravel](https://stackoverflow.com/questions/58646223/user-id-conflict-for-multiple-guards-laravel#:~:text=the%20laravel%20default-,DatabaseSessionHandler,-and%20override%20the)
- [Understanding Laravel Architecture](https://www.youtube.com/watch?v=W0KFGXx1HG8)



### 🧠 Rationale
I think authenticated checks are being redundant?

### 🧪 Test
1. Log in a user
2. Check in session table if user id remains on employee page for example

3. Visit admin dashboard for example, the admin login should not be accessible

[Manual](https://drive.google.com/file/d/19kGkD9thhChlBLdHkJ8lBJd2OPw7gs2-/view?usp=sharing)


### ✔️ Checklist
This is a set of criteria to ensure the correctness of your PR. Check each that applied.
- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
