### PR TITLE
fix(style/sidebar): added width for collpased sidebar

### DIFF
--- a/resources/scss/employee/_side-top-bar.scss
+++ b/resources/scss/employee/_side-top-bar.scss
@@ -8,7 +8,7 @@
 
 :root {
     --main-menu-padding-top: clamp(1rem, 0.5rem + 1dvh, 4rem);
-    --sidebar-width: clamp(160px, 16px + 1.5rem + 5vw, 200px);
+    --sidebar-width: clamp(48px, 8px + 1.25rem + 5vw, 200px);
     --sidebar-width-active: clamp(200px + 2rem, 128px + 1.5rem + 10vw, 696px + 4rem);
     --topbar-padding-x: clamp(1rem, 2dvw + 2.5vh, 10rem);
     --topnav-padding-x: clamp(1.25rem, 0.63rem + 2dvw, 4rem);
@@ -153,6 +153,7 @@ sidebar.main-menu {
 
     @media screen and (min-width: 576px) {
         min-width: fit-content;
+        width: var(--sidebar-width);
     }
 
     @extend %main-menu-padding-top;


### PR DESCRIPTION
### 🛠 Changes

- Quick fix for sidebar animation by specifying the width on collapsed sidebar
- Also adjust maintain the prescribe width

### 🧠 Rationale
I didn't include the compiled CSS on commit it may cause merge conflict with other pr

### 🧪 Test
I put my my finger on LCD to check for the width toggling the width style to check if it matches the with before with the changes

### 📸 Screenshots (Optional)
Before
![image](https://github.com/user-attachments/assets/3c70bf6b-9541-407b-a66b-d7a882b56ca4)

After
![image](https://github.com/user-attachments/assets/2904e7ef-c5ea-4fb4-934f-d4bf6a83e479)


### Steps
Check if the width of sidebar is okay as it may differ on my screen

### ✔️ Checklist
This is a set of criteria to ensure the correctness of your PR. Check each that applied.
- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
