### PR TITLE
feat(dashboard): presence channel for all user types and components separation

### DIFF
--- a/app/Livewire/Admin/Dashboard/DailyTimeRecord.php
+++ b/app/Livewire/Admin/Dashboard/DailyTimeRecord.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire\Admin\Dashboard;
+
+use Livewire\Component;
+
+class DailyTimeRecord extends Component
+{
+    public function render()
+    {
+        return view('livewire.admin.dashboard.daily-time-record');
+    }
+}

--- a/app/Livewire/Admin/Dashboard/InfoCards.php
+++ b/app/Livewire/Admin/Dashboard/InfoCards.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\Admin\Dashboard;
+
+use App\Models\User;
+use Livewire\Component;
+
+class InfoCards extends Component
+{
+    public function render()
+    {
+        $count = User::selectRaw(
+            'COUNT(*) AS total,
+            SUM(CASE WHEN email_verified_at IS NOT NULL THEN 1 ELSE 0 END) AS active'
+        )->first();
+
+        return view('livewire.admin.dashboard.info-cards', [
+            'activeUsersCount' => $count->active,
+            'totalUsersCount' => $count->total,
+        ]);
+    }
+}

--- a/app/Livewire/Admin/Dashboard/LatestAnnouncements.php
+++ b/app/Livewire/Admin/Dashboard/LatestAnnouncements.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire\Admin\Dashboard;
+
+use Livewire\Component;
+
+class LatestAnnouncements extends Component
+{
+    public function render()
+    {
+        return view('livewire.admin.dashboard.latest-announcements');
+    }
+}

--- a/app/Livewire/Admin/Dashboard/PulseAndActivityLogs.php
+++ b/app/Livewire/Admin/Dashboard/PulseAndActivityLogs.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire\Admin\Dashboard;
+
+use Livewire\Component;
+
+class PulseAndActivityLogs extends Component
+{
+    public function render()
+    {
+        return view('livewire.admin.dashboard.pulse-and-activity-logs');
+    }
+}

--- a/resources/js/admin/dashboard.js
+++ b/resources/js/admin/dashboard.js
@@ -5,7 +5,6 @@ import initLucideIcons from '../icons/lucide.js';
 import addGlobalListener from '../global-event-listener.js';
 import ThemeManager, { initPageTheme, handleThemeBtn } from '../theme-listener.js';
 import '../auth-listener.js';
-import '../listeners/online-users.js';
 
 const themeManager = new ThemeManager();
 const themeToggle = document.getElementById(`theme-toggle-btn`).closest('.dropdown');

--- a/resources/js/applicant/dashboard.js
+++ b/resources/js/applicant/dashboard.js
@@ -6,7 +6,6 @@ import addGlobalScrollListener, { documentScrollPosY } from '../global-scroll-fn
 import addGlobalListener, { GlobalListener } from '../global-event-listener.js';
 import ThemeManager, { initPageTheme, handleThemeBtn } from '../theme-listener.js';
 // import './livewire.js'
-import '../listeners/online-users.js';
 
 const themeManager = new ThemeManager();
 const themeToggle = document.getElementById(`theme-toggle-btn`).closest('.dropdown');

--- a/resources/js/employee/basic/dashboard.js
+++ b/resources/js/employee/basic/dashboard.js
@@ -8,7 +8,6 @@ import initLucideIcons from '../../icons/lucide.js';
 import addGlobalListener from '../../global-event-listener.js';
 import ThemeManager, { initPageTheme, handleThemeBtn } from '../../theme-listener.js';
 import '../../auth-listener.js';
-import '../../listeners/online-users.js';
 
 const themeManager = new ThemeManager();
 const themeToggle = document.getElementById(`theme-toggle-btn`).closest('.dropdown');

--- a/resources/js/employee/dashboard.js
+++ b/resources/js/employee/dashboard.js
@@ -8,7 +8,6 @@ import initLucideIcons from '../icons/lucide.js';
 import addGlobalListener from '../global-event-listener.js';
 import ThemeManager, { initPageTheme, handleThemeBtn } from '../theme-listener.js';
 import '../auth-listener.js';
-import '../listeners/online-users.js';
 
 const themeManager = new ThemeManager();
 const themeToggle = document.getElementById(`theme-toggle-btn`).closest('.dropdown');

--- a/resources/js/employee/hr-manager/dashboard.js
+++ b/resources/js/employee/hr-manager/dashboard.js
@@ -3,13 +3,6 @@ import GLOBAL_CONST from '../../global-constant.js';
 import initLucideIcons from '../../icons/lucide.js';
 import addGlobalListener from 'globalListener-script';
 import '../../auth-listener.js';
-import '../../listeners/online-users.js';
 import 'employee-page-script';
 import '../../modals.js';
 import '../../tooltip.js';
-
-
-
-
-
-

--- a/resources/js/listeners/online-users.js
+++ b/resources/js/listeners/online-users.js
@@ -1,12 +1,44 @@
-let onlineUsers = [];
+import '../websocket';
+
+let onlineUsers = Alpine.reactive([]);
 
 Echo.join('online-users')
     .here((users) => {
-        onlineUsers = users;
+        onlineUsers.splice(0, onlineUsers.length, ...users);
     })
     .joining((user) => {
         onlineUsers.push(user);
     })
     .leaving((user) => {
-        onlineUsers = onlineUsers.filter(u => u.user_id !== user.user_id);
+        const index = onlineUsers.findIndex(u => u.user_id === user.user_id);
+        if (index > -1) {
+            onlineUsers.splice(index, 1);
+        }
+    });
+
+Alpine.store('onlineUsers', {
+    list: onlineUsers,
+    currentPage: 1,
+    perPage: 5,
+
+    paginatedUsers() {
+        const start = (this.currentPage - 1) * this.perPage;
+        const end = start + this.perPage;
+        return this.list.slice(start, end);
+    },
+
+    changePage(page) {
+        const totalPages = Math.ceil(this.list.length / this.perPage);
+        if (page >= 1 && page <= totalPages) {
+            this.currentPage = page;
+        }
+    },
+
+    getTotalPages() {
+        return Math.ceil(this.list.length / this.perPage);
+    },
+
+    updateList() {
+        this.list = [...this.list];
+    }
 });

--- a/resources/views/components/layout/app.blade.php
+++ b/resources/views/components/layout/app.blade.php
@@ -34,6 +34,7 @@
     <x-authenticated-broadcast-id />
     <x-livewire-listener />
 
+    @vite(['resources/js/listeners/online-users.js'])
 
     {{--  Waiting for this fix in livewire https://github.com/livewire/livewire/pull/8793  --}}
     {{-- livewire.js?id=cc800bf4:9932 Detected multiple instances of Livewire running --}}

--- a/resources/views/components/layout/applicant/layout.blade.php
+++ b/resources/views/components/layout/applicant/layout.blade.php
@@ -33,6 +33,8 @@
     <!-- Scripts -->
     <x-authenticated-broadcast-id />
     <x-livewire-listener />
+    
+    @vite(['resources/js/listeners/online-users.js'])
 
     @once
         @livewireStyles()

--- a/resources/views/components/layout/employee/layout.blade.php
+++ b/resources/views/components/layout/employee/layout.blade.php
@@ -32,6 +32,8 @@
     <x-authenticated-broadcast-id />
     <x-livewire-listener />
 
+    @vite(['resources/js/listeners/online-users.js'])
+
     {{-- Waiting for this fix in livewire https://github.com/livewire/livewire/pull/8793 --}}
     {{-- livewire.js?id=cc800bf4:9932 Detected multiple instances of Livewire running --}}
     {{-- livewire.js?id=cc800bf4:9932 Detected multiple instances of Alpine running --}}

--- a/resources/views/employee/admin/index.blade.php
+++ b/resources/views/employee/admin/index.blade.php
@@ -1,7 +1,3 @@
-@php
-    $nonce = csp_nonce();
-@endphp
-
 @extends('components.layout.employee.layout', ['description' => 'Admin Dashboard', 'nonce' => $nonce])
 
 @section('head')
@@ -11,24 +7,8 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
 @endsection
 
-@pushOnce('pre-scripts')
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-@endPushOnce
-
 @pushOnce('scripts')
-    @vite(['resources/js/employee/hr-manager/dashboard.js'])
-
-    <!-- Adds the Core Table Styles -->
-    @rappasoftTableStyles
-
-    <!-- Adds any relevant Third-Party Styles (Used for DateRangeFilter (Flatpickr) and NumberRangeFilter) -->
-    @rappasoftTableThirdPartyStyles
-
-    <!-- Adds the Core Table Scripts -->
-    @rappasoftTableScripts
-
-    <!-- Adds any relevant Third-Party Scripts (e.g. Flatpickr) -->
-    @rappasoftTableThirdPartyScripts
+    @vite(['resources/js/admin/dashboard.js'])
 @endPushOnce
 
 @pushOnce('styles')
@@ -42,267 +22,26 @@
     <p>It is <time datetime="{{ now() }}"> {{ \Carbon\Carbon::now()->format('l, d F') }}</time></p>
 </hgroup>
 
-<!-- SECTION: Key Metrics -->
-<section role="navigation" aria-label="Key Metrics" class="mb-5 row">
-    <div class="col-md-3">
-        <div class="card bg-body-secondary border-0 py-4 card-start-border-teal">
-            <div class="row">
-                <div class="col-md-3 icons-container">
-                    <img class="icons-row-card"
-                        src="{{ Vite::asset('resources/images/illus/dashboard/active-accs.webp') }}" alt="">
-                </div>
-                <div class="col-md-7 mx-2">
-                    <p class="fw-medium fs-7 text-opacity-25">Active Accounts</p>
-                    <p class="fw-semibold fs-3">40</p>
-                </div>
-            </div>
-        </div>
-    </div>
+{{-- SECTION: Key Metrics --}}
+<livewire:admin.dashboard.info-cards />
 
-    <div class="col">
-        <div class="card bg-body-secondary border-0 py-4 card-start-border-green" role="none">
-            <div class="row">
-                <div class="col-md-3 icons-container">
-                    <img class="icons-row-card"
-                        src="{{ Vite::asset('resources/images/illus/dashboard/online-users.webp') }}" alt="">
-                </div>
-                <div class="col-md-7 mx-2">
-                    <p class="fw-medium fs-7 text-opacity-25">Online Users</p>
-                    <p class="fw-semibold fs-3">12</p>
-                </div>
-            </div>
-        </div>
-    </div>
+{{-- SECTION: Laravel Pulse & Recent Activity Logs --}}
+<livewire:admin.dashboard.pulse-and-activity-logs />
 
-    <div class="col">
-        <div class="card bg-body-secondary border-0 py-4 card-start-border-blue" role="none"
-            aria-describedby="attendance-nav-desc">
-            <div class="row">
-                <div class="col-md-3 icons-container">
-                    <img class="icons-row-card"
-                        src="{{ Vite::asset('resources/images/illus/dashboard/total-users.webp') }}" alt="">
-                </div>
-                <div class="col-md-7 mx-2">
-                    <p class="fw-medium fs-7 text-opacity-25">Total Users</p>
-                    <p class="fw-semibold fs-3">52</p>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="col">
-        <div class="card bg-body-secondary border-0 py-4 card-start-border-purple" role="none"
-            aria-describedby="attendance-nav-desc">
-            <div class="row">
-                <div class="col-md-3 icons-container">
-                    <img class="icons-row-card"
-                        src="{{ Vite::asset('resources/images/illus/dashboard/last-24-hours.webp') }}" alt="">
-                </div>
-                <div class="col-md-7 mx-2">
-                    <p class="fw-medium fs-7 text-opacity-25">Logins Within 24h</p>
-                    <p class="fw-semibold fs-3">40</p>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
-
-<!-- SECTION: Laravel Pulse & Recent Activity Logs -->
-<section class="mb-5">
-    <header class="fs-4 fw-bold mb-4" role="heading" aria-level="2">
-        Key Metrics & Logs
-    </header>
-
-    <div class="d-flex mb-5 row">
-
-        <!-- Laravel Pulse -->
-        <div class="col-md-6 d-flex">
-            <x-nav-link href="{{ route('admin.system.pulse') }}" class="unstyled w-100">
-                <div class="card p-4 pulse-card h-100">
-                    <div class="row">
-                        <div class="col-md-7">
-                            <div class="px-3 py-2">
-                                <div class="fs-2 fw-bold text-primary card-cont-green-hover">Laravel Pulse</div>
-                                <div class="fs-5 pt-2 fw-regular card-cont-green-hover">Check the system’s performance
-                                    and usage via Laravel Pulse.</div>
-                            </div>
-                        </div>
-                        <div class="col-md-5 image-container">
-                            <!-- Static Image -->
-                            <img class="static-image"
-                                src="{{ Vite::asset('resources/images/illus/dashboard/pulse-static.webp') }}" alt="">
-                            <!-- Animated Image -->
-                            <img class="animated-image"
-                                src="{{ Vite::asset('resources/images/illus/dashboard/pulse-animated.gif') }}" alt="">
-                        </div>
-                    </div>
-                </div>
-            </x-nav-link>
-        </div>
-
-        <!-- Recent Activity Logs -->
-        <div class="col-md-6 d-flex">
-            <div class="card border-primary p-4 h-100 w-100">
-                <div class="px-3">
-                    <div class="row">
-                        <div class="col-9">
-                            <div class="fs-3 fw-bold mb-3">Recent Activity Logs</div>
-                        </div>
-
-                        <div class="col-3">
-                            <div class="d-flex justify-content-end">
-                                <x-buttons.view-link-btn link="#" text="View All" />
-                            </div>
-                        </div>
-                    </div>
-                    <div class="w-100">
-
-                        <!-- BACK-END REPLACE: Recent Activity Logs. Limit to 2. -->
-                        <ul>
-                            <li>You deleted a <b>qualification</b> from Accountant.
-                            <li>You addeda <b>new open job position</b>: Janitor.</li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
-
-<!-- SECTION: Announcements & Daily Time Record -->
+{{-- SECTION: Announcements & Daily Time Record --}}
 <section class="mb-5">
     <div class="d-flex mb-5 row">
-
-        <!-- Announcement -->
-        <div class="col-md-7 flex announcement-box">
-            <!-- Header -->
-            <div class="px-4 pb-4">
-                <div class="d-flex align-items-center justify-content-between">
-                    <div class="d-flex align-items-center">
-                        <img class="img-size-10 img-responsive"
-                            src="{{ Vite::asset('resources/images/illus/dashboard/megaphone.png') }}" alt="">
-
-                        <span class="ms-3 green-highlight">
-                            Latest Announcements
-                        </span>
-                    </div>
-
-                    <!-- Button Link to Create Announcement -->
-                    <a href="{{ route('admin.announcement.create') }}" class="icon-link" data-bs-toggle="tooltip"
-                        title="Post an announcement">
-                        <div class="icon-container">
-                            <i data-lucide="plus" class="icon-with-border"></i>
-                        </div>
-                    </a>
-                </div>
-            </div>
-
-            <!-- Mock Data Only for color mapping. Remove once data is fetched dynamically. -->
-            @php
-                $announcements = [
-                    [
-                        'title' => 'New Policy Implementation',
-                        'description' => 'Effective next month, we will be implementing a new remote work policy. Please review the details in the policy section of the portal!',
-                        'roles' => ['Technical', 'Employee']
-                    ],
-                    [
-                        'title' => 'Work Anniversary',
-                        'description' => 'Happy 5th work anniversary to John Smith! Thank you for your dedication and hard work over the years.',
-                        'roles' => ['Accountant', 'Employee']
-                    ],
-                    [
-                        'title' => 'Company Picnic',
-                        'description' => 'Join us for the annual company picnic on July 15th at Central Park. Food, games, and fun for the whole family!',
-                        'roles' => ['Relations']
-                    ],
-                ];
-
-                // Bound to change.
-                $colorMapping = [
-                    'HR' => 'blue',
-                    'Employee' => 'teal',
-                    'Accountant' => 'green',
-                    'Relations' => 'purple',
-                    'Technical' => 'orange',
-                    'default' => 'purple',
-                ];
-            @endphp
-
-            <!-- The fetching section -->
-            @foreach ($announcements as $announcement)
-                <div class="card mb-3 bg-body-secondary border-0 p-4">
-                    <div class="w-100">
-                        <div>
-                            <header class="fs-5 fw-bold d-inline-block me-2">{{ $announcement['title'] }}
-                                @foreach ($announcement['roles'] as $role)
-                                    <x-status-badge :color="$colorMapping[$role] ?? $colorMapping['default']">{{ $role }}</x-status-badge>
-                                @endforeach
-                            </header>
-
-                            <p class="fs-7">{{ $announcement['description'] }}</p>
-                        </div>
-                    </div>
-                </div>
-            @endforeach
-
-        </div>
-
-        <!-- Daily Time Record -->
-        <div class="col-md-5 flex">
-            <div class="card p-4">
-                <div class="table-attendance-cont">
-                    <header class="fs-4 fw-bold" role="heading" aria-level="2">
-                        <i class="bi bi-circle-fill text-danger fs-4"></i>
-                        <span class="text-danger text-uppercase fw-bold">Live</span>
-                        Daily Time Record
-                    </header>
-
-                    <table class="table table-borderless table-attendance-list">
-                        <thead>
-                            <tr>
-                                <th>Employee</th>
-                                <th>Time In</th>
-                                <th>Time Out</th>
-                            </tr>
-                        </thead>
-
-                        <!-- BACK-END REPLACE: DTI from Database. Limit to 5. -->
-                        <tbody>
-                            @for ($i = 0; $i < 5; $i++)
-                                <tr>
-                                    <td>{{ fake()->name() }}</td>
-                                    <td>{{ fake()->time() }}</td>
-                                    <td>{{ fake()->time() }}</td>
-                                </tr>
-                            @endfor
-                        </tbody>
-                    </table>
-
-                    <!-- Redirect Link: To Attendance -->
-                    <div class="col-12 px-5">
-                        <x-buttons.view-link-btn link="#" text="View All" />
-                    </div>
-                </div>
-            </div>
-        </div>
+        <livewire:admin.dashboard.latest-announcements />
+        <livewire:admin.dashboard.daily-time-record />
     </div>
 </section>
 
-<!-- SECTION: High Level View of Users Table -->
 <section class="mb-5">
-    <header class="fs-4 fw-bold mb-4" role="heading" aria-level="2">
-        Users
-    </header>
-
-    <div class="d-flex mb-5">
-        <div class="col-md-12">
-            <div class="card p-4 h-100">
-                <!-- Insert here the Users table. Its supposed width is 100vw. -->
-                List of Users Table
-            </div>
+    <div class="d-flex mb-5 row">
+        <div class="col-7">
+            {{-- I don't what should go here --}}
         </div>
-    </div>
+    <livewire:admin.dashboard.online-users />            
+    </div>    
 </section>
-
-<!-- <livewire:admin.dashboard.online-users /> -->
 @endsection

--- a/resources/views/livewire/admin/dashboard/daily-time-record.blade.php
+++ b/resources/views/livewire/admin/dashboard/daily-time-record.blade.php
@@ -1,0 +1,37 @@
+<div class="col-md-5 flex">
+    <div class="card p-4">
+        <div class="table-attendance-cont">
+            <header class="fs-4 fw-bold" role="heading" aria-level="2">
+                <i class="bi bi-circle-fill text-danger fs-4"></i>
+                <span class="text-danger text-uppercase fw-bold">Live</span>
+                Daily Time Record
+            </header>
+
+            <table class="table table-borderless table-attendance-list">
+                <thead>
+                    <tr>
+                        <th>Employee</th>
+                        <th>Time In</th>
+                        <th>Time Out</th>
+                    </tr>
+                </thead>
+
+                <!-- BACK-END REPLACE: DTI from Database. Limit to 5. -->
+                <tbody>
+                    @for ($i = 0; $i < 5; $i++)
+                        <tr>
+                            <td>{{ fake()->name() }}</td>
+                            <td>{{ fake()->time() }}</td>
+                            <td>{{ fake()->time() }}</td>
+                        </tr>
+                    @endfor
+                </tbody>
+            </table>
+
+            <!-- Redirect Link: To Attendance -->
+            <div class="col-12 px-5">
+                <x-buttons.view-link-btn link="#" text="View All" />
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/admin/dashboard/info-cards.blade.php
+++ b/resources/views/livewire/admin/dashboard/info-cards.blade.php
@@ -1,0 +1,63 @@
+<section role="navigation" aria-label="Key Metrics" class="mb-5 row" x-data>
+    <div class="col-md-3">
+        <div class="card bg-body-secondary border-0 py-4 card-start-border-teal">
+            <div class="row">
+                <div class="col-md-3 icons-container">
+                    <img class="icons-row-card"
+                        src="{{ Vite::asset('resources/images/illus/dashboard/active-accs.webp') }}" alt="">
+                </div>
+                <div class="col-md-7 mx-2">
+                    <p class="fw-medium fs-7 text-opacity-25">{{ __('Active Users') }}</p>
+                    <p class="fw-semibold fs-3">{{ $activeUsersCount }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col">
+        <div class="card bg-body-secondary border-0 py-4 card-start-border-green" role="none">
+            <div class="row">
+                <div class="col-md-3 icons-container">
+                    <img class="icons-row-card"
+                        src="{{ Vite::asset('resources/images/illus/dashboard/online-users.webp') }}" alt="">
+                </div>
+                <div class="col-md-7 mx-2">
+                    <p class="fw-medium fs-7 text-opacity-25">Online Users</p>
+                    <p class="fw-semibold fs-3" x-text="$store.onlineUsers.list.length"></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col">
+        <div class="card bg-body-secondary border-0 py-4 card-start-border-blue" role="none"
+            aria-describedby="attendance-nav-desc">
+            <div class="row">
+                <div class="col-md-3 icons-container">
+                    <img class="icons-row-card"
+                        src="{{ Vite::asset('resources/images/illus/dashboard/total-users.webp') }}" alt="">
+                </div>
+                <div class="col-md-7 mx-2">
+                    <p class="fw-medium fs-7 text-opacity-25">{{ __('Total Users') }}</p>
+                    <p class="fw-semibold fs-3">{{ $totalUsersCount }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col">
+        <div class="card bg-body-secondary border-0 py-4 card-start-border-purple" role="none"
+            aria-describedby="attendance-nav-desc">
+            <div class="row">
+                <div class="col-md-3 icons-container">
+                    <img class="icons-row-card"
+                        src="{{ Vite::asset('resources/images/illus/dashboard/last-24-hours.webp') }}" alt="">
+                </div>
+                <div class="col-md-7 mx-2">
+                    <p class="fw-medium fs-7 text-opacity-25">{{ __('Logins in 24h') }}</p>
+                    <p class="fw-semibold fs-3">40</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/resources/views/livewire/admin/dashboard/latest-announcements.blade.php
+++ b/resources/views/livewire/admin/dashboard/latest-announcements.blade.php
@@ -1,0 +1,72 @@
+<div class="col-md-7 flex announcement-box">
+    <!-- Header -->
+    <div class="px-4 pb-4">
+        <div class="d-flex align-items-center justify-content-between">
+            <div class="d-flex align-items-center">
+                <img class="img-size-10 img-responsive"
+                    src="{{ Vite::asset('resources/images/illus/dashboard/megaphone.png') }}" alt="">
+
+                <span class="ms-3 green-highlight">
+                    Latest Announcements
+                </span>
+            </div>
+
+            <!-- Button Link to Create Announcement -->
+            <a href="{{ route('admin.announcement.create') }}" class="icon-link" data-bs-toggle="tooltip"
+                title="Post an announcement">
+                <div class="icon-container">
+                    <i data-lucide="plus" class="icon-with-border"></i>
+                </div>
+            </a>
+        </div>
+    </div>
+
+    <!-- Mock Data Only for color mapping. Remove once data is fetched dynamically. -->
+    @php
+        $announcements = [
+            [
+                'title' => 'New Policy Implementation',
+                'description' => 'Effective next month, we will be implementing a new remote work policy. Please review the details in the policy section of the portal!',
+                'roles' => ['Technical', 'Employee']
+            ],
+            [
+                'title' => 'Work Anniversary',
+                'description' => 'Happy 5th work anniversary to John Smith! Thank you for your dedication and hard work over the years.',
+                'roles' => ['Accountant', 'Employee']
+            ],
+            [
+                'title' => 'Company Picnic',
+                'description' => 'Join us for the annual company picnic on July 15th at Central Park. Food, games, and fun for the whole family!',
+                'roles' => ['Relations']
+            ],
+        ];
+
+        // Bound to change.
+        $colorMapping = [
+            'HR' => 'blue',
+            'Employee' => 'teal',
+            'Accountant' => 'green',
+            'Relations' => 'purple',
+            'Technical' => 'orange',
+            'default' => 'purple',
+        ];
+    @endphp
+
+    <!-- The fetching section -->
+    @foreach ($announcements as $announcement)
+        <div class="card mb-3 bg-body-secondary border-0 p-4">
+            <div class="w-100">
+                <div>
+                    <header class="fs-5 fw-bold d-inline-block me-2">{{ $announcement['title'] }}
+                        @foreach ($announcement['roles'] as $role)
+                            <x-status-badge :color="$colorMapping[$role] ?? $colorMapping['default']">{{ $role }}</x-status-badge>
+                        @endforeach
+                    </header>
+
+                    <p class="fs-7">{{ $announcement['description'] }}</p>
+                </div>
+            </div>
+        </div>
+    @endforeach
+
+</div>

--- a/resources/views/livewire/admin/dashboard/online-users.blade.php
+++ b/resources/views/livewire/admin/dashboard/online-users.blade.php
@@ -1,40 +1,67 @@
-<section>
-    <header class="fs-4 fw-bold mb-4" role="heading" aria-level="2">
-        Online Users
-    </header>
-    
-    <div
-        x-data="{ onlineUsers: [] }"
-        x-init="
-            Echo.join('online-users')
-                .here((users) => {
-                    onlineUsers = users.filter(u => u.user_id !== {{ auth()->user()->user_id }});
-                })
-                .joining((user) => {
-                    onlineUsers.push(user);
-                })
-                .leaving((user) => {
-                    onlineUsers = onlineUsers.filter(u => u.user_id !== user.user_id);
-                });
-        "
+<div class="col-5">
+    <div 
+        x-data="{ 
+            online: $store.onlineUsers,
+            authUserId: {{ auth()->user()->user_id }} 
+        }"
+        class="card mb-3"
     >
-        <div class="d-flex">
+        <div class="card-header w-100 px-3"> 
+            <header class="fs-4 fw-bold" role="heading" aria-level="2">
+                <span class="fs-4 fw-bold text-primary pe-2" x-text="online.list.length"></span>
+                {{ __('Online Users') }} 
+            </header>
+        </div>
+
+        <div class="card-body px-3">   
             <ul class="list-unstyled">
-                <template x-if="onlineUsers.length > 0">
-                    <template x-for="user in onlineUsers" :key="user.user_id">
-                        <li>
+                <template x-if="online.paginatedUsers().length > 0">
+                    <template x-for="user in online.paginatedUsers()" :key="user.user_id">
+                        <li class="d-flex align-items-center mb-2 p-2 rounded-3 bg-body-secondary">
                             <x-online-status status="online">
-                                <img :src="user.photo" alt="user" class="img-fluid rounded-circle" width="35" height="35" />
-                            </x-online-status>                           
-                            <span class="ps-1" x-text="user.email"></span>    
+                                <img :src="user.photo" alt="User Photo" class="img-fluid rounded-circle border" width="40" height="40">
+                            </x-online-status>
+                            <div class="ms-3">
+                                <div class="fw-bold text-uppercase">
+                                    <span x-text="user.fullName"></span>
+                                    <template x-if="user.user_id === authUserId">
+                                        <span class="fw-medium text-capitalize">{{ __('(You)') }}</span>
+                                    </template>
+                                </div>
+                                <div class="text-muted" x-text="user.email"></div>
+                            </div>
                         </li>
                     </template>
                 </template>
 
-                <template x-if="onlineUsers.length === 0">
-                    <li>No online people</li>
+                <template x-if="online.paginatedUsers().length === 0">
+                    <li class="text-muted"> {{ __('No online users') }}</li>
                 </template>
             </ul>
         </div>
-    </div>  
-</section>
+
+        <div class="card-footer">
+            <button
+                @click="online.changePage(online.currentPage - 1)" 
+                :disabled="online.currentPage === 1" 
+                class="btn btn-sm border-0"
+            >
+                <i data-lucide="chevron-left"></i>
+            </button>
+
+            <span>
+                <span x-text="online.currentPage"></span> 
+                {{ __('of') }} 
+                <span x-text="online.getTotalPages()"></span>
+            </span>
+
+            <button
+                @click="online.changePage(online.currentPage + 1)" 
+                :disabled="online.currentPage === online.getTotalPages()" 
+                class="btn btn-sm border-0"
+            >
+                <i data-lucide="chevron-right"></i>
+            </button>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/admin/dashboard/pulse-and-activity-logs.blade.php
+++ b/resources/views/livewire/admin/dashboard/pulse-and-activity-logs.blade.php
@@ -1,0 +1,60 @@
+<section class="mb-5">
+    <header class="fs-4 fw-bold mb-4" role="heading" aria-level="2">
+        Key Metrics & Logs
+    </header>
+
+    <div class="d-flex mb-5 row">
+
+        <!-- Laravel Pulse -->
+        <div class="col-md-6 d-flex">
+            <x-nav-link href="{{ route('admin.system.pulse') }}" class="unstyled w-100">
+                <div class="card p-4 pulse-card h-100">
+                    <div class="row">
+                        <div class="col-md-7">
+                            <div class="px-3 py-2">
+                                <div class="fs-2 fw-bold text-primary card-cont-green-hover">Laravel Pulse</div>
+                                <div class="fs-5 pt-2 fw-regular card-cont-green-hover">Check the system’s performance
+                                    and usage via Laravel Pulse.</div>
+                            </div>
+                        </div>
+                        <div class="col-md-5 image-container">
+                            <!-- Static Image -->
+                            <img class="static-image"
+                                src="{{ Vite::asset('resources/images/illus/dashboard/pulse-static.webp') }}" alt="">
+                            <!-- Animated Image -->
+                            <img class="animated-image"
+                                src="{{ Vite::asset('resources/images/illus/dashboard/pulse-animated.gif') }}" alt="">
+                        </div>
+                    </div>
+                </div>
+            </x-nav-link>
+        </div>
+
+        <!-- Recent Activity Logs -->
+        <div class="col-md-6 d-flex">
+            <div class="card border-primary p-4 h-100 w-100">
+                <div class="px-3">
+                    <div class="row">
+                        <div class="col-9">
+                            <div class="fs-3 fw-bold mb-3">Recent Activity Logs</div>
+                        </div>
+
+                        <div class="col-3">
+                            <div class="d-flex justify-content-end">
+                                <x-buttons.view-link-btn link="#" text="View All" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="w-100">
+
+                        <!-- BACK-END REPLACE: Recent Activity Logs. Limit to 2. -->
+                        <ul>
+                            <li>You deleted a <b>qualification</b> from Accountant.
+                            <li>You addeda <b>new open job position</b>: Janitor.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -20,8 +20,13 @@ Broadcast::channel('user_auth.{userBroadcastId}', function ($user, string $userB
 Broadcast::channel('online-users', function (User $user){
     if (Auth::check()) {
         $userPhoto = $user->photo ?? Storage::url('icons/default-avatar.png');
+        $user->load('account');
+        $fullName = $user->account->full_name;
 
-        return array_merge($user->only(['user_id', 'email']), ['photo' => $userPhoto]);
+        return array_merge(
+            $user->only(['user_id', 'email']), 
+            ['photo' => $userPhoto, 'fullName' => $fullName]
+        );
     }
     return false;
 });


### PR DESCRIPTION
### 🛠 Changes

- Modify `online-users.js` for pagination and enabling global access to online user list variable.
- Separate each component of the dashboard for modularity and separation of concerns.
- Remove imports of `online-users.js` from js files it was included. Perhaps this is good since I think not every available browsers supports javascript ES6 modules.

### 📸 Screenshots (Optional)

Online users component

![image](https://github.com/user-attachments/assets/a925178a-2673-4e38-92f8-ae18f1a25fbd)


### ✔️ Checklist
This is a set of criteria to ensure the correctness of your PR. Check each that applied.
- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
