### PR TITLE
chore: secondary approver overtimes

### DIFF
--- a/app/Enums/UserPermission.php
+++ b/app/Enums/UserPermission.php
@@ -71,7 +71,7 @@ enum UserPermission: string
     case VIEW_ALL_ATTENDANCE_WORKHOURS = 'view all attendance by workhours';
     case VIEW_DOWNLOAD_PAYROLL_SUMMARY = 'view download all computed attendance summary';
     case VIEW_ALL_LEAVES = 'view all leave requests';
-    case VIEW_ALL_OVERTIME = 'view all overtime requests';
+    case VIEW_ALL_OVERTIME_REQUEST = 'view all overtime requests';
     case VIEW_ALL_PAYSLIPS = 'view all payslips';
     case VIEW_ALL_ISSUES = 'view all employee issues';
     case VIEW_ALL_TRAINING = 'view all employee trainings';
@@ -114,13 +114,11 @@ enum UserPermission: string
     case UPDATE_EMP_PERFORMANCE_EVAL_GRADE_FORM = 'update employee performance evaluation grade form';
     case UPDATE_EMP_PERFORMANCE_EVAL_APPROVAL_FORM = 'update employee performance evaluation approval form';
     case UPDATE_EMP_PERFORMANCE_EVAL_FINAL_APPROVAL_FORM = 'update employee performance evaluation final approval form';
-    case UPDATE_PENDING_LEAVE_REQUEST = 'update pending leave request';
-    case UPDATE_APPROVED_LEAVE_REQUEST = 'update approved leave request';
     case UPDATE_LEAVE_BALANCE = 'update leave balance';
     case UPDATE_PERFORMANCE_CATEGORIES = 'update performance categories';
     case UPDATE_PERFORMANCE_RATING_SCALES = 'update performance rating scales';
     case UPDATE_PREEMPLOYMENT_REQUIREMENTS = 'update pre employment requirements';
-    case UPDATE_OVERTIME_REQUEST = 'update overtime request';
+    case UPDATE_ALL_OVERTIME_REQUEST = 'update every employee overtime request';
     case UPDATE_PENDING_OVERTIME_REQUEST_STATUS = 'update pending overtime request status';
     case UPDATE_APPROVED_OVERTIME_REQUEST_STATUS = 'update approved overtime request status';
     case UPDATE_ISSUE_COMPLAINT = 'update issue complaint';
@@ -205,7 +203,7 @@ enum UserPermission: string
             self::VIEW_ALL_ATTENDANCE_WORKHOURS => 'View all attendance by workhours',
             self::VIEW_DOWNLOAD_PAYROLL_SUMMARY => 'Download all computed attendance summary',
             self::VIEW_ALL_LEAVES => 'View all leave requests',
-            self::VIEW_ALL_OVERTIME => 'View all overtime requests',
+            self::VIEW_ALL_OVERTIME_REQUEST => 'View all overtime requests',
             self::VIEW_ALL_PAYSLIPS => 'View all payslips',
             self::VIEW_ALL_EMP_PERFORMANCE_EVAL => 'View all performance evaluation records',
             self::VIEW_ALL_EMP_PERFORMANCE_TRAINING => 'View all performance training records',
@@ -247,13 +245,11 @@ enum UserPermission: string
             self::UPDATE_EMP_PERFORMANCE_EVAL_GRADE_FORM => 'Update employee performance evaluation grade form',
             self::UPDATE_EMP_PERFORMANCE_EVAL_APPROVAL_FORM => 'Update employee performance evaluation approval form',
             self::UPDATE_EMP_PERFORMANCE_EVAL_FINAL_APPROVAL_FORM => 'Update employee performance evaluation final approval form',
-            self::UPDATE_PENDING_LEAVE_REQUEST => 'Update pending leave request',
-            self::UPDATE_APPROVED_LEAVE_REQUEST => 'Update approved leave request',
             self::UPDATE_LEAVE_BALANCE => 'Update leave balance',
             self::UPDATE_PERFORMANCE_CATEGORIES => 'Update performance categories',
             self::UPDATE_PERFORMANCE_RATING_SCALES => 'Update performance rating scales',
             self::UPDATE_PREEMPLOYMENT_REQUIREMENTS => 'Update pre-employment requirements',
-            self::UPDATE_OVERTIME_REQUEST => 'Update overtime request',
+            self::UPDATE_ALL_OVERTIME_REQUEST => 'Update every employee overtime request status',
             self::UPDATE_PENDING_OVERTIME_REQUEST_STATUS => 'Update pending overtime request status',
             self::UPDATE_APPROVED_OVERTIME_REQUEST_STATUS => 'Update approved overtime request status',
             self::UPDATE_ISSUE_COMPLAINT => 'Update an issue complaint',

--- a/app/Http/Controllers/OvertimeController.php
+++ b/app/Http/Controllers/OvertimeController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Gate;
+
+class OvertimeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return view('employee.basic.overtime.all');
+    }
+
+    /**
+     * For initial approvers (supervisors / dept head)
+     * 
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function initialApprovals()
+    {
+        return view('employee.supervisor.requests.overtime.all');
+    }
+
+    /**
+     * For secondary approvers (hr staff / manager)
+     * 
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function secondaryApprovals()
+    {
+        return view('employee.hr-manager.overtime.all');
+    }
+
+    /**
+     * Show recent overtime requests table.
+     */
+    public function recent()
+    {
+        return view('employee.basic.overtime.recent-records');
+    }
+
+    /**
+     * Show archive overtime requests table.
+     */
+    public function archive()
+    {
+        return view('employee.basic.overtime.index');
+    }
+}

--- a/app/Livewire/Admin/AttendanceLogsTable.php
+++ b/app/Livewire/Admin/AttendanceLogsTable.php
@@ -111,12 +111,12 @@ class AttendanceLogsTable extends DataTableComponent
             Column::make(__('Time'), 'timestamp')
                 ->sortable()
                 ->searchable()
-                ->format(fn ($value, $row, Column $column) => Carbon::parse($row->timestamp)->format('g:i A')),
+                ->format(fn ($value, $row, Column $column) => Carbon::make($row->timestamp)->format('g:i A')),
 
             Column::make(__('Date'), 'timestamp')
                 ->sortable()
                 ->searchable()
-                ->format(fn ($value, $row, Column $column) => Carbon::parse($row->timestamp)->format('F d, Y')),
+                ->format(fn ($value, $row, Column $column) => Carbon::make($row->timestamp)->format('F d, Y')),
         ];
     }
 }

--- a/app/Livewire/Employee/Overtimes/Basic/EditOvertimeRequest.php
+++ b/app/Livewire/Employee/Overtimes/Basic/EditOvertimeRequest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Livewire\Employee\Overtimes\Basic;
+
+use App\Enums\Payroll;
+use Livewire\Component;
+use App\Models\Overtime;
+use Illuminate\Support\Str;
+use Livewire\Attributes\On;
+use Illuminate\Support\Carbon;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Computed;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use App\Livewire\Employee\Tables\Basic\RecentOvertimesTable;
+use App\Livewire\Employee\Tables\Basic\ArchiveOvertimesTable;
+
+class EditOvertimeRequest extends Component
+{
+    public $state = [
+        'workToPerform' => '',
+        'date' => null,
+        'startTime' => null,
+        'endTime' => null,
+    ];
+
+    /**
+     * Set attributes in readable format.
+     */
+    #[Locked]
+    public $overtime;
+
+    public ?Overtime $request = null;
+
+    #[Locked]
+    public $hoursRequested = 0;
+
+    #[Locked]
+    public $editMode = false;
+
+    public function update()
+    {
+        if ($this->editMode) {
+
+            if (! $this->request) {
+                abort (403);
+            }
+
+            $this->authorize('updateOvertimeRequest', [$this->employee, $this->request]);
+
+            $this->validate();
+
+            DB::transaction(function () {
+                $this->request->update([
+                    'employee_id' => $this->employee->employee_id,
+                    'work_performed' => $this->state['workToPerform'],
+                    'date' => $this->state['date'],
+                    'start_time' => $this->state['startTime'],
+                    'end_time' => $this->state['endTime'],
+                    'cut_off' => $this->getCutOffType(),
+                ]);
+            });    
+        }
+        
+        $this->reset();
+        $this->resetErrorBag();
+
+        $this->dispatch('changesSaved')->to(ArchiveOvertimesTable::class);
+        $this->dispatch('changesSaved')->to(RecentOvertimesTable::class);
+        $this->dispatch('changesSaved');
+    }
+
+    #[On('showOvertimeRequest')]
+    public function openEditMode(int $overtimeId)
+    {
+        $this->request = Overtime::with([
+                'processes',
+                'processes.initialApprover',
+                'processes.secondaryApprover',
+                'processes.deniedBy',
+            ])->find($overtimeId);
+
+        if (! $this->request) {
+            $this->dispatch('modelNotFound', [
+                'feedbackMsg' => __('Sorry, it seems like this record has been removed.'),
+            ]);
+        } else {
+            $this->state = [
+                'overtimeId' => $this->request->overtime_id,
+                'workToPerform' => $this->request->work_performed,
+                'date' => Carbon::parse($this->request->date)->format('Y-m-d'),
+                'startTime' => Carbon::parse($this->request->start_time)->format('H:i'),
+                'endTime' => Carbon::parse($this->request->end_time)->format('H:i'),
+            ];
+            $this->hoursRequested = $this->request->getHoursRequested();
+            
+            $this->makeKeysReadable();
+
+            if (Gate::allows('editOvertimeRequest', $this->request)) {
+                $this->editMode = true;
+            }
+
+            $this->dispatch('openOvertimeRequestModal');
+        }
+    }
+
+    private function getCutOffType()
+    {
+        $selectedDate = Carbon::parse($this->state['date']);
+        return Payroll::getCutOffPeriodForDate($selectedDate);
+    }
+
+    private function makeKeysReadable()
+    {
+        $this->overtime = (object) [
+            'filedAt'                   =>  $this->request->filed_at,
+            'initiallyApprovedBy'       =>  $this->request?->processes?->first()?->initialApprover?->full_name,
+            'initiallyApprovedAt'       =>  $this->request?->processes?->first()?->initial_approver_signed_at,
+            'secondaryApprovedBy'       =>  $this->request?->processes?->first()?->secondaryApprover?->full_name,
+            'secondaryApprovedAt'       =>  $this->request?->processes?->first()?->secondary_approver_signed_at,
+            'deniedBy'                  =>  $this->request?->processes?->first()?->deniedBy?->full_name,
+            'deniedAt'                  =>  $this->request?->processes?->first()?->denied_at,
+            'feedback'                  =>  $this->request?->processes?->first()?->feedback,
+        ];
+    }
+
+    #[Computed]
+    private function employee()
+    {
+        return Auth::user()->account;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'state.workToPerform' => 'required|string|max:100',
+            'state.date' => 'required|date|after_or_equal:today',
+            'state.startTime' => 'required|date_format:H:i',
+            'state.endTime' => 'required|date_format:H:i|after:state.startTime',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'state.workToPerform.required' => __('Please provide a description.'),
+            'state.workToPerform.string' => __('Description must be a valid string.'),
+            'state.workToPerform.max' => __('Description must not exceed 100 characters.'),
+            'state.date.required' => __('Please provide a valid date.'),
+            'state.date.date' => __('The date must be a valid format.'),
+            'state.date.after_or_equal' => __('The date must not be in the past.'),
+            'state.startTime.required' => __('Please provide a start time.'),
+            'state.startTime.date_format' => __('The start time must be in the format HH:mm.'),
+            'state.endTime.required' => __('Please provide an end time.'),
+            'state.endTime.date_format' => __('The end time must be in the format HH:mm.'),
+            'state.endTime.after' => __('The end time must be after the start time.'),
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.employee.overtimes.basic.edit-overtime-request');
+    }
+}

--- a/app/Livewire/Employee/Tables/Basic/ArchiveOvertimesTable.php
+++ b/app/Livewire/Employee/Tables/Basic/ArchiveOvertimesTable.php
@@ -36,21 +36,15 @@ class ArchiveOvertimesTable extends DataTableComponent
         ]);
 
         $this->setTrAttributes(function ($row, $index) {
-            $attributes = [
+            return [
                 'default' => true,
                 'class' => 'border-1 rounded-2 outline no-transition mx-4',
+                'role' => 'button',
+                'wire:click' => "\$dispatchTo(
+                    'employee.overtimes.basic.edit-overtime-request', 
+                    'showOvertimeRequest', 
+                    { overtimeId: $row->overtime_id })",
             ];
-
-            $pendingStatus = is_null($row->processes->first()->secondary_approver_signed_at);
-
-            if ($pendingStatus) {
-                $attributes = array_merge($attributes, [
-                    'role' => 'button',
-                    'wire:click' => "\$dispatch('showOvertimeRequest', $row->overtime_id)",
-                ]);
-            }
-
-            return $attributes;
         });
 
         $this->setSearchFieldAttributes([

--- a/app/Livewire/Employee/Tables/Basic/RecentOvertimesTable.php
+++ b/app/Livewire/Employee/Tables/Basic/RecentOvertimesTable.php
@@ -39,21 +39,15 @@ class RecentOvertimesTable extends DataTableComponent
         ]);
 
         $this->setTrAttributes(function ($row, $index) {
-            $attributes = [
+            return [
                 'default' => true,
                 'class' => 'border-1 rounded-2 outline no-transition mx-4',
+                'role' => 'button',
+                'wire:click' => "\$dispatchTo(
+                    'employee.overtimes.basic.edit-overtime-request', 
+                    'showOvertimeRequest', 
+                    { overtimeId: $row->overtime_id })",
             ];
-
-            $pendingStatus = is_null($row->processes->first()->secondary_approver_signed_at);
-
-            if ($pendingStatus) {
-                $attributes = array_merge($attributes, [
-                    'role' => 'button',
-                    'wire:click' => "\$dispatch('showOvertimeRequest', $row->overtime_id)",
-                ]);
-            }
-
-            return $attributes;
         });
 
         $this->setSearchFieldAttributes([

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -157,8 +157,8 @@ class Employee extends Model
      */
     protected function getShiftScheduleAttribute()
     {
-        $start = Carbon::parse($this->shift->start_time)->format('g:i A');
-        $end = Carbon::parse($this->shift->end_time)->format('g:i A');
+        $start = Carbon::make($this->shift->start_time)->format('g:i A');
+        $end = Carbon::make($this->shift->end_time)->format('g:i A');
 
         return "{$start} - {$end}";
     }

--- a/app/Models/Overtime.php
+++ b/app/Models/Overtime.php
@@ -37,8 +37,8 @@ class Overtime extends Model
     protected function startTime(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => Carbon::parse($value)->format('g:i A'),
-            set: fn (mixed $value) => Carbon::parse($value)->format('H:i:s'),
+            get: fn (mixed $value) => Carbon::make($value)->format('g:i A'),
+            set: fn (mixed $value) => Carbon::make($value)->format('H:i:s'),
         );
     }
     
@@ -48,8 +48,8 @@ class Overtime extends Model
     protected function endTime(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => Carbon::parse($value)->format('g:i A'),
-            set: fn (mixed $value) => Carbon::parse($value)->format('H:i:s'),
+            get: fn (mixed $value) => Carbon::make($value)->format('g:i A'),
+            set: fn (mixed $value) => Carbon::make($value)->format('H:i:s'),
         );
     }
 
@@ -59,7 +59,7 @@ class Overtime extends Model
     protected function filedAt(): Attribute
     {
         return Attribute::make(
-            get: fn (mixed $value) => Carbon::parse($value)->format('F d, Y')
+            get: fn (mixed $value) => Carbon::make($value)->format('F d, Y g:i A')
         );
     }
 
@@ -77,7 +77,7 @@ class Overtime extends Model
     public function date(): Attribute
     {
         return Attribute::make(
-            set: fn (mixed $value) => Carbon::parse($value)->format('Y-m-d')
+            set: fn (mixed $value) => Carbon::make($value)->format('Y-m-d')
         );
     }
 

--- a/app/Models/Process.php
+++ b/app/Models/Process.php
@@ -2,10 +2,12 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Process extends Model
 {
@@ -18,6 +20,36 @@ class Process extends Model
     protected $guarded = [
         'process_id',
     ];
+
+    /**
+     * Accessor for initial approval date (formatted).
+     */
+    protected function initialApproverSignedAt(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value) => Carbon::make($value)?->format('F d, Y g:i A') ?? null,
+        );
+    }
+
+    /**
+     * Accessor for secondary / final approval date (formatted).
+     */
+    protected function secondaryApproverSignedAt(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value) => Carbon::make($value)?->format('F d, Y g:i A') ?? null,
+        );
+    }
+
+    /**
+     * Accessor for request denied date (formatted).
+     */
+    protected function deniedAt(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value) => Carbon::make($value)?->format('F d, Y g:i A') ?? null,
+        );
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -44,7 +76,7 @@ class Process extends Model
     /**
      * Get the secondary approver who denied the process(e.g.: overtime, leave)
      */
-    public function denier(): BelongsTo
+    public function deniedBy(): BelongsTo
     {
         return $this->belongsTo(Employee::class, 'denier', 'employee_id');
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -131,6 +131,10 @@ class AppServiceProvider extends ServiceProvider
         Gate::define('submitOvertimeRequestToday', [OvertimePolicy::class, 'submitOvertimeRequestToday']);
         Gate::define('submitNewOrAnotherOvertimeRequest', [OvertimePolicy::class, 'submitNewOrAnotherOvertimeRequest']);
         Gate::define('updateSubordinateOvertimeRequest', [OvertimePolicy::class, 'updateSubordinateOvertimeRequest']);
+        Gate::define('viewOvertimeRequestAsSecondaryApprover', [OvertimePolicy::class, 'viewOvertimeRequestAsSecondaryApprover']);
+        Gate::define('viewOvertimeRequestAsInitialApprover', [OvertimePolicy::class, 'viewOvertimeRequestAsInitialApprover']);
+        Gate::define('updateAllOvertimeRequest', [OvertimePolicy::class, 'updateAllOvertimeRequest']);
+        Gate::define('editOvertimeRequest', [OvertimePolicy::class, 'editOvertimeRequest']);
 
         Vite::useAggressivePrefetching();
     }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -78,7 +78,7 @@ class RolesAndPermissionsSeeder extends Seeder
             UserPermission::VIEW_DOWNLOAD_ALL_ATTENDANCE->value,
             UserPermission::VIEW_DOWNLOAD_PAYROLL_SUMMARY->value,
             UserPermission::VIEW_ALL_LEAVES->value,
-            UserPermission::VIEW_ALL_OVERTIME->value,
+            UserPermission::VIEW_ALL_OVERTIME_REQUEST->value,
             UserPermission::VIEW_ALL_PAYSLIPS->value,
             UserPermission::VIEW_ALL_EMP_PERFORMANCE_EVAL->value,
             UserPermission::VIEW_ALL_EMP_PERFORMANCE_EVAL_GRADE_FORM->value,
@@ -107,13 +107,12 @@ class RolesAndPermissionsSeeder extends Seeder
             UserPermission::UPDATE_EMP_PERFORMANCE_EVAL_GRADE_FORM->value,
             UserPermission::UPDATE_EMP_PERFORMANCE_EVAL_APPROVAL_FORM->value,
             UserPermission::UPDATE_EMP_PERFORMANCE_EVAL_FINAL_APPROVAL_FORM->value,
-            UserPermission::UPDATE_PENDING_LEAVE_REQUEST->value,
-            UserPermission::UPDATE_APPROVED_LEAVE_REQUEST->value,
             UserPermission::UPDATE_LEAVE_BALANCE->value,
             UserPermission::UPDATE_PENDING_OVERTIME_REQUEST_STATUS->value,
             UserPermission::UPDATE_APPROVED_OVERTIME_REQUEST_STATUS->value,
             UserPermission::UPDATE_ISSUE_COMPLAINT_CLOSED->value,
             UserPermission::UPDATE_ISSUE_COMPLAINT_RESOLVED->value,
+            UserPermission::UPDATE_ALL_OVERTIME_REQUEST->value,
 
             // Delete cases goes here
         ];

--- a/resources/views/components/layout/employee/nav/sidebar/employee-navs.blade.php
+++ b/resources/views/components/layout/employee/nav/sidebar/employee-navs.blade.php
@@ -40,10 +40,10 @@
     /**
      * Overtime
      */
-    $navOvertimeOrder = $user->hasPermissionTo(UserPermission::VIEW_ALL_OVERTIME) ? 6 : 4; // Adjust order as needed
-    $navOvertimeRoute = $user->hasPermissionTo(UserPermission::VIEW_ALL_OVERTIME)
-        ? $routePrefix . '.hr.overtime.all'
-        : $routePrefix . '.overtimes';
+    $navOvertimeOrder = $user->hasPermissionTo(UserPermission::VIEW_ALL_OVERTIME_REQUEST) ? 6 : 4; // Adjust order as needed
+    $navOvertimeRoute = $user->hasPermissionTo(UserPermission::VIEW_ALL_OVERTIME_REQUEST)
+        ? $routePrefix . '.overtimes.requests.secondary'
+        : $routePrefix . '.overtimes.index';
 
 
     /**
@@ -152,7 +152,7 @@
     </x-layout.employee.nav.sidebar.nav-item>
     @endcan
 
-    @canAny([UserPermission::VIEW_OVERTIME, UserPermission::VIEW_ALL_OVERTIME])
+    @canAny([UserPermission::VIEW_OVERTIME, UserPermission::VIEW_ALL_OVERTIME_REQUEST])
     <x-layout.employee.nav.sidebar.nav-item
         :href="route($navOvertimeRoute)"
         :active="request()->routeIs($navOvertimeRoute)"
@@ -330,7 +330,7 @@
             :defaultIcon="['src' => 'requests', 'alt' => 'Performance']"
             :activeIcon="['src' => 'requests', 'alt' => 'Relations']" :children="[
                 ['href' => route($routePrefix . '.managerial.requests.leaves.all'), 'active' => request()->routeIs($routePrefix . '.managerial.requests.leaves.all'), 'nav_txt' => 'Leaves'],
-                ['href' => route($routePrefix . '.overtimes.requests'), 'active' => request()->routeIs($routePrefix . '.overtimes.requests'), 'nav_txt' => 'Overtime'],
+                ['href' => route($routePrefix . '.overtimes.requests.initial'), 'active' => request()->routeIs($routePrefix . '.overtimes.requests.initial'), 'nav_txt' => 'Overtime'],
             ]">
         </x-layout.employee.nav.sidebar.nested-nav-items>
     @endcan

--- a/resources/views/components/modals/dialog.blade.php
+++ b/resources/views/components/modals/dialog.blade.php
@@ -6,7 +6,6 @@
     wire:ignore.self 
     class="modal fade" 
     id="{{ $id }}" 
-    tabindex="-1" 
     aria-labelledby="{{ $id }}-label"
     {{ $attributes->merge([
         'data-bs-backdrop' => 'true',

--- a/resources/views/employee/basic/overtime/index.blade.php
+++ b/resources/views/employee/basic/overtime/index.blade.php
@@ -19,7 +19,7 @@
 
 <x-breadcrumbs>
     <x-slot:breadcrumbs>
-        <x-breadcrumb :href="route($routePrefix . '.overtimes')">
+        <x-breadcrumb :href="route($routePrefix . '.overtimes.index')">
             {{ __('Overtime Summaries') }}
         </x-breadcrumb>
         <x-breadcrumb :active="request()->routeIs($routePrefix . '.overtimes.archive')">

--- a/resources/views/employee/basic/overtime/recent-records.blade.php
+++ b/resources/views/employee/basic/overtime/recent-records.blade.php
@@ -19,7 +19,7 @@
 
 <x-breadcrumbs>
     <x-slot:breadcrumbs>
-        <x-breadcrumb :href="route($routePrefix . '.overtimes')">
+        <x-breadcrumb :href="route($routePrefix . '.overtimes.index')">
             {{ __('Overtime Summaries') }}
         </x-breadcrumb>
         <x-breadcrumb :active="request()->routeIs($routePrefix . '.overtimes.recents')">

--- a/resources/views/employee/hr-manager/overtime/all.blade.php
+++ b/resources/views/employee/hr-manager/overtime/all.blade.php
@@ -2,33 +2,32 @@
 @use ('Illuminate\View\ComponentAttributeBag')
 
 @section('head')
-<title>Employee Name's Performance Evaluation Results</title><!-- Replace with Employee Name -->
+<title>Overtime Request Approval</title>
 <script rel="preload" as="script" type="text/js" src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 <script src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 @endsection
 
-@pushOnce('pre-scripts')
-@endPushOnce
-
 @pushOnce('scripts')
     @vite(['resources/js/employee/hr-manager/performance.js'])
-
 @endPushOnce
 
 @pushOnce('styles')
     @vite(['resources/css/employee/hr-manager/performance.css'])
-
 @endPushOnce
+
 @section('content')
 
 <x-headings.main-heading :isHeading="true">
     <x-slot:heading>
-        {{ __('Overtime Tables') }}
+        {{ __('Overtime Requests') }}
     </x-slot:heading>
 
     <x-slot:description>
-        {{ __('View and manage.') }}
+        {{ __('Manage overtime requests here.') }}
     </x-slot:description>
 </x-headings.main-heading>
 
-    @endsection
+<livewire:employee.tables.all-overtime-requests-table />
+<livewire:employee.overtimes.secondary-overtime-request-approval />
+
+@endsection

--- a/resources/views/employee/supervisor/requests/overtime/all.blade.php
+++ b/resources/views/employee/supervisor/requests/overtime/all.blade.php
@@ -7,17 +7,14 @@
 <script src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 @endsection
 
-@pushOnce('pre-scripts')
-@endPushOnce
-
 @pushOnce('scripts')
     @vite(['resources/js/employee/hr-manager/performance.js'])
 @endPushOnce
 
 @pushOnce('styles')
     @vite(['resources/css/employee/hr-manager/performance.css'])
-
 @endPushOnce
+
 @section('content')
 
 <x-headings.main-heading :isHeading="true">

--- a/resources/views/livewire/employee/overtimes/basic/cut-off-payout-periods.blade.php
+++ b/resources/views/livewire/employee/overtimes/basic/cut-off-payout-periods.blade.php
@@ -31,4 +31,5 @@
         <!-- BACK-END REPLACE NOTE: This button should not appear if the OT Summary Form being viewed is history/not the current payroll period. -->
     </div>
     <livewire:employee.overtimes.basic.request-overtime />
+    <livewire:employee.overtimes.basic.edit-overtime-request />
 </section>

--- a/resources/views/livewire/employee/overtimes/basic/edit-overtime-request.blade.php
+++ b/resources/views/livewire/employee/overtimes/basic/edit-overtime-request.blade.php
@@ -1,0 +1,137 @@
+@props([
+    'modalId' => 'editOvertimeRequestModal'
+])
+
+<div>
+    <x-modals.dialog data-bs-backdrop="static" data-bs-keyboard="false" :id="$modalId">
+        <x-slot:title class="">
+            <h1 class="modal-title fs-5 fw-bold text-secondary-emphasis" id="{{ $modalId }}">{{ __('Request Overtime') }}</h1>
+            <button wire:click="$dispatch('resetOvertimeRequestModal')" wire:loading.attr="disabled" class="btn-close" aria-label="Close"></button>        
+        </x-slot:title>
+        
+        <x-slot:content>
+            <div class="mb-3">
+                <x-form.boxed-input-text name="state.workToPerform" id="work_performed" label="{{ __('Work To Perform') }}" :nonce="$nonce"
+                    :required="true" placeholder="Detail of the work to be done" :readonly="! $editMode" />
+                @error('state.workToPerform')
+                    <div class="invalid-feedback" role="alert">{{ $message }}</div>
+                @enderror
+            </div>
+            
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <x-form.boxed-date name="state.date" id="date_ovt" label="{{ __('Date') }}" :nonce="$nonce" :required="true"
+                        placeholder="Date of Overtime" :readonly="! $editMode" />
+                    @error('state.date')
+                        <div class="invalid-feedback" role="alert">{{ $message }}</div>
+                    @enderror
+                </div>
+                
+                <div class="col-md-3 mb-3">
+                    <x-form.boxed-time wire:model.live="state.startTime" id="hours_ot" label="{{ __('Start Time') }}" :nonce="$nonce" :required="true"
+                    placeholder="Start Time" :readonly="! $editMode" />
+                    @error('state.startTime')
+                        <div class="invalid-feedback" role="alert">{{ $message }}</div>
+                    @enderror
+                </div>
+                
+                <div class="col-md-3">
+                    <x-form.boxed-time wire:model.live="state.endTime" id="hours_ot" label="{{ __('End Time') }}" :nonce="$nonce" :required="true"
+                    placeholder="End Time" :readonly="! $editMode" />
+                    @error('state.endTime')
+                        <div class="invalid-feedback" role="alert">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+            
+            <div class="fs-6 fw-medium text-secondary-emphasis">
+                <div class="">{{ __("Requested Hours: {$hoursRequested}") }}</div>
+                <div class="">{{ __("Date Filed: {$overtime?->filedAt}") }}</div>
+            </div>
+
+            <div class="list-group">
+                @if ($overtime?->initiallyApprovedAt)
+                    <hr>
+                    <div class="list-group-item border-0 ps-0">
+                        <h6 class="fw-semibold text-primary">{{ __('Initially Approved') }}</h6>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="text-secondary-emphasis">{{ __('by: ') }}
+                                <span class="fw-semibold">
+                                    {{ $overtime?->initiallyApprovedBy }}
+                                </span>
+                            </span>
+                            <span class="text-muted small">{{ $overtime?->initiallyApprovedAt }}</span>
+                        </div>
+                    </div>
+                @endif
+
+                @if ($overtime?->secondaryApprovedAt)
+                    <hr>
+                    <div class="list-group-item border-0 ps-0">
+                        <h6 class="fw-semibold text-primary">{{ __('Secondarily Approved') }}</h6>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="text-secondary-emphasis">{{ __('by: ') }}
+                                <span class="fw-semibold">
+                                    {{ $overtime?->secondaryApprovedBy }}
+                                </span>
+                            </span>
+                            <span class="text-muted small">{{ $overtime?->secondaryApprovedAt }}</span>
+                        </div>
+                    </div>
+                @endif
+
+                @if ($overtime?->deniedAt)
+                    <hr>
+                    <div class="list-group-item border-0 ps-0">
+                        <h6 class="fw-semibold text-danger">{{ __('Request Denied') }}</h6>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="text-secondary-emphasis">{{ __('by: ') }}
+                                <span class="fw-semibold">
+                                    {{ $overtime?->deniedBy }}
+                                </span>
+                            </span>
+                            <span class="text-muted small">{{ $overtime?->deniedAt }}</span>
+                        </div>
+                        <div class="mt-3">
+                            <label for="feedback" class="form-label text-muted">{{ __('Reason:') }}</label>
+                            <textarea id="feedback" class="form-control bg-body-secondary" rows="3" readonly>{{ $overtime?->feedback }}</textarea>
+                        </div>
+                    </div>
+                @endif
+            </div>
+        </x-slot:content>
+        <x-slot:footer>
+            @if($editMode)
+                <div class="d-flex justify-content-between align-items-center w-100 text-secondary-emphasis">
+                    <div class="me-auto">
+                        <p class="fs-6 fw-medium mb-0">
+                            <strong>Instructions: </strong>{{ __('Overtime submissions require a minimum of 30 minutes.') }}
+                        </p>
+                    </div>
+                    <div class="ms-auto">
+                        <button wire:click="update" wire:loading.attr="disabled" class="btn btn-primary">
+                            {{ __('Submit Request') }}
+                        </button>
+                    </div>
+                </div>
+            @endif
+        </x-slot:footer>                
+    </x-modals.dialog>
+</div>
+
+
+@script
+<script>
+    $wire.on('showOvertimeRequest', (event) => {
+        openModal('{{ $modalId }}');
+    });
+
+    $wire.on('resetOvertimeRequestModal', () => {
+        hideModal('{{ $modalId }}')
+    });
+
+    Livewire.on('changesSaved', () => {
+        hideModal('{{ $modalId }}');     
+    })
+</script>
+@endscript

--- a/resources/views/livewire/employee/overtimes/basic/request-overtime.blade.php
+++ b/resources/views/livewire/employee/overtimes/basic/request-overtime.blade.php
@@ -3,11 +3,12 @@
 ])
 
 <div>
-    <x-modals.dialog :id="$modalId">
+    <x-modals.dialog data-bs-backdrop="static" data-bs-keyboard="false" :id="$modalId">
         <x-slot:title class="">
-            <h1 class="modal-title fs-5 fw-bold text-secondary-emphasis" id="{{ $modalId }}">{{ $title }}</h1>
-            <button @click="$dispatch('abortAction')" wire:loading.attr="disabled" class="btn-close" aria-label="Close"></button>        
+            <h1 class="modal-title fs-5 fw-bold text-secondary-emphasis" id="{{ $modalId }}">{{ __('Request Overtime') }}</h1>
+            <button wire:click="$dispatch('resetOvertimeRequestModal')" wire:loading.attr="disabled" class="btn-close" aria-label="Close"></button>        
         </x-slot:title>
+        
         <x-slot:content>
             <div class="mb-3">
                 <x-form.boxed-input-text name="state.workToPerform" id="work_performed" label="{{ __('Work To Perform') }}" :nonce="$nonce"
@@ -16,6 +17,7 @@
                     <div class="invalid-feedback" role="alert">{{ $message }}</div>
                 @enderror
             </div>
+            
             <div class="row">
                 <div class="col-md-6 mb-3">
                     <x-form.boxed-date name="state.date" id="date_ovt" label="{{ __('Date') }}" :nonce="$nonce" :required="true"
@@ -24,25 +26,29 @@
                         <div class="invalid-feedback" role="alert">{{ $message }}</div>
                     @enderror
                 </div>
+                
                 <div class="col-md-3 mb-3">
                     <x-form.boxed-time wire:model.live="state.startTime" id="hours_ot" label="{{ __('Start Time') }}" :nonce="$nonce" :required="true"
-                    placeholder="Date of Overtime" />
+                    placeholder="Start Time" />
                     @error('state.startTime')
                         <div class="invalid-feedback" role="alert">{{ $message }}</div>
                     @enderror
                 </div>
+                
                 <div class="col-md-3">
                     <x-form.boxed-time wire:model.live="state.endTime" id="hours_ot" label="{{ __('End Time') }}" :nonce="$nonce" :required="true"
-                    placeholder="Date of Overtime" />
+                    placeholder="End Time" />
                     @error('state.endTime')
                         <div class="invalid-feedback" role="alert">{{ $message }}</div>
                     @enderror
                 </div>
             </div>
+            
             <p class="fs-6 fw-medium text-secondary-emphasis">
                 <strong>{{ __('Requested Hours: ') }}</strong>{{ $hoursRequested }}
             </p>
         </x-slot:content>
+        
         <x-slot:footer>
             <div class="d-flex justify-content-between align-items-center w-100 text-secondary-emphasis">
                 <div class="me-auto">
@@ -52,7 +58,7 @@
                 </div>
                 <div class="ms-auto">
                     <button wire:click="save" wire:loading.attr="disabled" class="btn btn-primary">
-                        {{ $buttonName }}
+                        {{ __('Submit Request') }}
                     </button>
                 </div>
             </div>
@@ -60,22 +66,12 @@
     </x-modals.dialog>
 </div>
 
+
 @script
 <script>
-    Livewire.on('showOvertimeRequest', (event) => {
-        // console.log(event)
-        if (event) {
-            Livewire.dispatch('findModelId', { overtimeId: event });
-        };
+    $wire.on('resetOvertimeRequestModal', () => {
+        hideModal('{{ $modalId }}')
     });
-
-    Livewire.on('openOvertimeRequestModal', () => {
-        openModal('{{ $modalId }}');
-    })
-
-    Livewire.on('resetOvertimeRequestModal', () => {
-        hideModal('{{ $modalId }}');
-    })
 
     Livewire.on('changesSaved', () => {
         hideModal('{{ $modalId }}');     

--- a/resources/views/livewire/employee/overtimes/secondary-overtime-request-approval.blade.php
+++ b/resources/views/livewire/employee/overtimes/secondary-overtime-request-approval.blade.php
@@ -48,6 +48,9 @@
                                     {{ $overtime?->requestorJobTitle }}
                                 </div>
                                 <div class="text-muted fs-6">
+                                    {{ $overtime?->requestorJobFamily }}
+                                </div>
+                                <div class="text-muted fs-6">
                                     {{ "Level {$overtime?->requestorJobLevel}: {$overtime?->requestorJobLevelName}" }}
                                 </div>
                                 <div class="text-muted fs-6">
@@ -243,7 +246,7 @@
     const footer = document.getElementById('footer');
     const modalId = document.getElementById('{{ $modalId }}');
 
-    $wire.on('showOvertimeRequestApproval', () => {
+    $wire.on('showPreApprovedOvertimeRequestApproval', () => {
         collapsible.hide();
         openModal('{{ $modalId }}');
     });

--- a/resources/views/livewire/placeholder/overtime-request-content.blade.php
+++ b/resources/views/livewire/placeholder/overtime-request-content.blade.php
@@ -1,0 +1,14 @@
+<div class="d-flex flex-column align-items-center justify-content-center">
+    <div class="d-flex">
+        <div class="spinner-grow spinner-grow-sm me-2" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+        <div class="spinner-grow spinner-grow-sm me-2" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+        <div class="spinner-grow spinner-grow-sm" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+    <div class="pt-4 text-center">{{ __('Crunching the latest data for you...') }}</div>
+</div>

--- a/routes/employee.php
+++ b/routes/employee.php
@@ -4,12 +4,13 @@ use App\Models\Employee;
 use App\Enums\UserPermission;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\EmployeeController;
+use App\Http\Controllers\OvertimeController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\ApplicationExamController;
 use App\Http\Controllers\InitialInterviewController;
+use App\Http\Controllers\PerformanceDetailController;
 use App\Http\Controllers\Employee\DashboardController;
 use App\Http\Controllers\Application\ApplicationController;
-use App\Http\Controllers\PerformanceDetailController;
 use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
 
 Route::middleware('guest')->group(function () {
@@ -51,6 +52,7 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
     /**
      * View Specific Application Details
      */
+
     Route::get('/applicant/{application}', [ApplicationController::class, 'show'])
         ->middleware([
             'permission:' . UserPermission::VIEW_APPLICATION_INFORMATION->value . '&(' . UserPermission::VIEW_ALL_PENDING_APPLICATIONS->value
@@ -152,12 +154,34 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
 
 
     /**
-     * Overtime
+     * Overtime resource
+     * 
+     * TODO: Idk if Ivan plans to add middleware checks, but do them below.
      */
+    Route::prefix('overtimes')->name('overtimes.')->group(function () {
 
-     Route::get('hr/overtime/all', function () {
-        return view('employee.hr-manager.overtime.all');
-    })->name('hr.overtime.all');
+        /** For initial approvals e.g: supervisor, dept head, area manager */
+        Route::get('requests/initial', [OvertimeController::class, 'initialApprovals'])
+            ->can('viewOvertimeRequestAsInitialApprover')
+            ->name('requests.initial');
+
+        /** For secondary approvals e.g: hr staff / manager */
+        Route::get('requests/secondary', [OvertimeController::class, 'secondaryApprovals'])
+            ->can('viewOvertimeRequestAsSecondaryApprover')
+            ->name('requests.secondary');
+
+        /** Ot requests summary */
+        Route::get('/', [OvertimeController::class, 'index'])
+            ->name('index');
+
+        /** Ot requests recents */
+        Route::get('recents', [OvertimeController::class, 'recent'])
+            ->name('recents');
+
+        /** Ot requests archive */
+        Route::get('archive', [OvertimeController::class, 'archive'])
+            ->name('archive');
+    });
 
 
     /**
@@ -242,17 +266,6 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
 
 
     /**
-     * Overtime
-     */
-
-    Route::get('overtimes/requests', function () {
-        return view('employee.supervisor.requests.overtime.all');
-    })
-        ->can(UserPermission::VIEW_SUBORDINATE_OVERTIME_REQUEST)
-        ->name('overtimes.requests');
-
-
-    /**
      * Performance Evaluations
      */
 
@@ -319,22 +332,6 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
     Route::get('general/leaves/view', function () {
         return view('employee.basic.leaves.view');
     })->name('general.leaves.view');
-
-
-    /**
-     * General: Overtime
-     */
-    Route::get('/overtimes', function () {
-        return view('employee.basic.overtime.all');
-    })->name('overtimes');
-
-    Route::get('/overtimes/recents', function () {
-        return view('employee.basic.overtime.recent-records');
-    })->name('overtimes.recents');
-
-    Route::get('/overtimes/archive', function () {
-        return view('employee.basic.overtime.index');
-    })->name('overtimes.archive');
 
 
     /**


### PR DESCRIPTION
### 🛠 Changes

- Additional user permissions were added as well as gates for more security.
- Whenever a basic user submit an overtime request, he can freely modify it as he see fit, as long as that request hasn't been approved or denied yet by the initial approver.
- Base implementation of secondary approver for overtime request is now also available.
- I think i can move on to other modules at this point.
- Should close #177 #181 

### 📸 Screenshots (Optional)

![image](https://github.com/user-attachments/assets/185adada-e0e7-4f57-a9ae-c0d66bdf7ff8)


### ✔️ Checklist

- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
