### PR TITLE
chore(models/migrations): employee `skills` `educations` `experiences`

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -459,6 +459,30 @@ class Employee extends Model
     }
 
     /**
+     * Get the educational attainments of the employee.
+     */
+    public function educations(): HasMany
+    {
+        return $this->hasMany(EmployeeEducation::class, 'employee_id', 'employee_id');
+    }
+
+    /**
+     * Get the work experiences of the employee.
+     */
+    public function experiences(): HasMany
+    {
+        return $this->hasMany(EmployeeExperience::class, 'employee_id', 'employee_id');
+    }
+
+    /**
+     * Get the skills of the employee.
+     */
+    public function skills(): HasMany
+    {
+        return $this->hasMany(EmployeeSkill::class, 'employee_id', 'employee_id');
+    }
+
+    /**
      * Override default values for more controlled logging.
      */
     public function getActivityLogOptions(): LogOptions

--- a/app/Models/EmployeeEducation.php
+++ b/app/Models/EmployeeEducation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class EmployeeEducation extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'employee_education_id';
+
+    protected $fillable = [
+        'employee_id',
+        'education',
+    ];
+
+    /**
+     * Get the employee that owns the education record.
+     */
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'employee_id', 'employee_id');
+    }
+}

--- a/app/Models/EmployeeExperience.php
+++ b/app/Models/EmployeeExperience.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class EmployeeExperience extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'employee_exp_id';
+
+    protected $fillable = [
+        'employee_id',
+        'experience_desc',
+    ];
+
+    /**
+     * Get the employee that owns the experience record.
+     */
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'employee_id', 'employee_id');
+    }
+}

--- a/app/Models/EmployeeSkill.php
+++ b/app/Models/EmployeeSkill.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EmployeeSkill extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'employee_skill_id';
+
+    protected $fillable = [
+        'employee_id',
+        'skills',
+    ];
+
+    /**
+     * Get the employee that owns the skill record.
+     */
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'employee_id', 'employee_id');
+    }
+}

--- a/database/migrations/2024_09_03_113157_create_employees_table.php
+++ b/database/migrations/2024_09_03_113157_create_employees_table.php
@@ -46,8 +46,6 @@ return new class extends Migration
             $table->string('tin_no', 12)->unique();
             $table->string('pag_ibig_no', 12)->unique();
             $table->binary('signature')->nullable();
-            $table->jsonb('education')->nullable();
-            $table->jsonb('experience')->nullable();
             $table->timestamps();
         });
 

--- a/database/migrations/2024_12_21_112946_create_employee_skills_table.php
+++ b/database/migrations/2024_12_21_112946_create_employee_skills_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Employee;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_skills', function (Blueprint $table) {
+            $table->id('employee_skill_id');
+
+            $table->foreignIdFor(Employee::class, 'employee_id')
+                ->constrained('employees', 'employee_id')
+                ->cascadeOnUpdate()
+                ->cascadeOnDelete();
+
+            $table->longText('skill');
+            $table->timestamps();
+            $table->index(['skill']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_skills');
+    }
+};

--- a/database/migrations/2024_12_21_112954_create_employee_education_table.php
+++ b/database/migrations/2024_12_21_112954_create_employee_education_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Employee;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_education', function (Blueprint $table) {
+            $table->id('employee_education_id');
+
+            $table->foreignIdFor(Employee::class, 'employee_id')
+                ->constrained('employees', 'employee_id')
+                ->cascadeOnUpdate()
+                ->cascadeOnDelete();
+
+            $table->longText('education');
+            $table->timestamps();
+            $table->index(['education']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_education');
+    }
+};

--- a/database/migrations/2024_12_21_113001_create_employee_experiences_table.php
+++ b/database/migrations/2024_12_21_113001_create_employee_experiences_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Employee;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_experiences', function (Blueprint $table) {
+            $table->id('employee_exp_id');
+
+            $table->foreignIdFor(Employee::class, 'employee_id')
+                ->constrained('employees', 'employee_id')
+                ->cascadeOnUpdate()
+                ->cascadeOnDelete();
+
+            $table->longText('experience_desc');
+            $table->timestamps();
+            $table->index(['experience_desc']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_experiences');
+    }
+};


### PR DESCRIPTION
### 🛠 Changes

- New models `EmployeeExperience` `EmployeeEducation` `EmployeeSkill`.
- The fields `skills` `experience_desc` and `education` are indexed since they aren't likely to change.

### ✨ Context

- PR thread from #185 

### 🧪 Test

- Seems like relationships are correctly defined here.

**`EmployeeExperience`** model

![image](https://github.com/user-attachments/assets/04addb09-faff-4c4a-9cac-4cf84da037f2)

**`EmployeeSkill`** model

![image](https://github.com/user-attachments/assets/3f09b3b9-5135-4bdb-84cf-b004f90488cd)

**`EmployeeEducation`** model

![image](https://github.com/user-attachments/assets/a0c538e1-a175-4f1f-ac74-7aae1afc2df3)

### ✔️ Checklist

- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
