### PR TITLE
perf: implement caching on employee

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    public function index()
+    {
+        return view('employee.profile.information.index');
+    }
+
+    public function edit()
+    {
+        return view('employee.profile.information.edit');
+    }
+
+    public function settings()
+    {
+        return view('employee.profile.settings');    
+    }
+
+    public function logs()
+    {
+        return view('employee.profile.activity-logs');
+    }
+}

--- a/app/Livewire/HrManager/Employees/Information.php
+++ b/app/Livewire/HrManager/Employees/Information.php
@@ -2,11 +2,12 @@
 
 namespace App\Livewire\HrManager\Employees;
 
-use App\Http\Helpers\Timezone;
 use Livewire\Component;
 use App\Models\Employee;
+use App\Http\Helpers\Timezone;
 use Illuminate\Support\Carbon;
 use Livewire\Attributes\Locked;
+use Illuminate\Support\Facades\Cache;
 
 class Information extends Component
 {
@@ -17,31 +18,50 @@ class Information extends Component
 
     public function mount(Employee $employee)
     {
-        $this->employee = (object) [
-            'id' => $employee->employee_id,
-            'name' => $employee->full_name,
-            'email' => $employee->account->email,
-            'photo' => $employee->account->photo,
-            'fullPresentAddress' => $employee->full_present_address,
-            'fullPermanentAddress' => $employee->full_permanent_address,
-            'contactNo' => $employee->contact_number,
-            'sex' => $employee->sex,
-            'civilStatus' => $employee->civil_status,
-            'jobTitle' => $employee->jobTitle->job_title,
-            'jobLevel' => $employee->jobTitle->jobLevel->job_level,
-            'jobLevelName' => $employee->jobTitle->jobLevel->job_level_name,
-            'jobFamily' => $employee->jobTitle->jobFamily->job_family_name,
-            'employmentStatus' => $employee->status->emp_status_name,
-            'shift' => $employee->shift->shift_name,
-            'shiftSched' => $employee->shift_schedule,
-            'hiredAt' => $employee?->application?->hired_at,
-            'dob' => $this->parseDateToReadableFormat($employee->date_of_birth),
-            'sss' => $employee->sss_no,
-            'philHealth' => $employee->philhealth_no,
-            'tin' => $employee->tin_no,
-            'pagIbig' => $employee->pag_ibig_no,
-            'registeredAt' => $this->parseDateToReadableFormat($employee->created_at),
-        ];
+        $key = sprintf(config('cache.keys.profile.information'), $employee->employee_id);
+        
+        if (Cache::has($key)) {
+            $this->employee = Cache::get($key);
+        } else {
+            $employee->loadMissing([
+                'account',
+                'jobTitle' => [
+                    'jobLevel',
+                    'jobFamily'
+                ],
+                'status',
+                'shift',
+                'application',
+            ]);
+
+            $this->employee = Cache::rememberForever($key, function () use ($employee) {
+                return (object) [
+                    'id'                    => $employee->employee_id,
+                    'name'                  => $employee->full_name,
+                    'email'                 => $employee->account->email,
+                    'photo'                 => $employee->account->photo,
+                    'fullPresentAddress'    => $employee->full_present_address,
+                    'fullPermanentAddress'  => $employee->full_permanent_address,
+                    'contactNo'             => $employee->contact_number,
+                    'sex'                   => $employee->sex,
+                    'civilStatus'           => $employee->civil_status,
+                    'jobTitle'              => $employee->jobTitle->job_title,
+                    'jobLevel'              => $employee->jobTitle->jobLevel->job_level,
+                    'jobLevelName'          => $employee->jobTitle->jobLevel->job_level_name,
+                    'jobFamily'             => $employee->jobTitle->jobFamily->job_family_name,
+                    'employmentStatus'      => $employee->status->emp_status_name,
+                    'shift'                 => $employee->shift->shift_name,
+                    'shiftSched'            => $employee->shift_schedule,
+                    'hiredAt'               => $employee?->application?->hired_at,
+                    'dob'                   => $this->parseDateToReadableFormat($employee->date_of_birth),
+                    'sss'                   => $employee->sss_no,
+                    'philHealth'            => $employee->philhealth_no,
+                    'tin'                   => $employee->tin_no,
+                    'pagIbig'               => $employee->pag_ibig_no,
+                    'registeredAt'          => $this->parseDateToReadableFormat($employee->created_at),
+                ];
+            });
+        }
     }
 
     public function boot()

--- a/app/Livewire/Profile/Information.php
+++ b/app/Livewire/Profile/Information.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use Livewire\Component;
+use Livewire\Attributes\Locked;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+
+class Information extends Component
+{
+    #[Locked]
+    public $employee;
+
+    public function mount()
+    {
+        $user = Auth::user();
+
+        $key = sprintf(config('cache.keys.profile.information'), $user->account->employee_id);
+
+        if (Cache::has($key)) {
+            $this->employee = Cache::get($key);
+        } else {
+            $user->loadMissing([
+                'account' => [
+                    'jobTitle' => [
+                        'jobLevel',
+                        'jobFamily'
+                    ],
+                    'status',
+                    'shift',
+                    'application'
+                ],
+            ]);
+
+            $this->employee = Cache::rememberForever($key, function () use ($user) {
+                return (object) [
+                    'userId'                => $user->user_id,
+                    'name'                  => $user->account->full_name,
+                    'email'                 => $user->email,
+                    'photo'                 => $user->photo,
+                    'fullPresentAddress'    => $user->account->full_present_address,
+                    'fullPermanentAddress'  => $user->account->full_permanent_address,
+                    'contactNo'             => $user->account->contact_number,
+                    'sex'                   => $user->account->sex,
+                    'civilStatus'           => $user->account->civil_status,
+                    'jobTitle'              => $user->account->jobTitle->job_title,
+                    'jobLevel'              => $user->account->jobTitle->jobLevel->job_level,
+                    'jobLevelName'          => $user->account->jobTitle->jobLevel->job_level_name,
+                    'jobFamily'             => $user->account->jobTitle->jobFamily->job_family_name,
+                    'employmentStatus'      => $user->account->status->emp_status_name,
+                    'shift'                 => $user->account->shift->shift_name,
+                    'shiftSched'            => $user->account->shift_schedule,
+                    'hiredAt'               => $user->account?->application?->hired_at,
+                    'dob'                   => $user->account->date_of_birth,
+                    'sss'                   => $user->account->sss_no,
+                    'philHealth'            => $user->account->philhealth_no,
+                    'tin'                   => $user->account->tin_no,
+                    'pagIbig'               => $user->account->pag_ibig_no,
+                ];                   
+            });
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.profile.information');
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -131,6 +131,14 @@ class Employee extends Model
      */
     protected function getFullPresentAddressAttribute()
     {
+        $this->loadMissing([
+            'presentBarangay' => [
+                'city',
+                'province',
+                'region'
+            ],
+        ]);
+
         $barangay = $this->presentBarangay->name;
         $city = $this->presentBarangay->city->name ?? '';
         $province = $this->presentBarangay->province->name ?? '';
@@ -144,6 +152,14 @@ class Employee extends Model
      */
     protected function getFullPermanentAddressAttribute()
     {
+        $this->loadMissing([
+            'permanentBarangay' => [
+                'city',
+                'province',
+                'region'
+            ],
+        ]);
+
         $barangay = $this->permanentBarangay->name;
         $city = $this->permanentBarangay->city->name ?? '';
         $province = $this->permanentBarangay->province->name ?? '';

--- a/config/cache.php
+++ b/config/cache.php
@@ -117,5 +117,8 @@ return [
                 'evaluation' => 'probationaries.performance.evaluation-%s'
             ],
         ],
+        'profile' => [
+            'information' => 'profile.information-%s',
+        ],
     ],
 ];

--- a/resources/views/components/includes/tab_navs/settings-privacy-navs.blade.php
+++ b/resources/views/components/includes/tab_navs/settings-privacy-navs.blade.php
@@ -8,11 +8,11 @@
     [
         'title' => 'Security',
         'icon' => 'shield-plus',
-        'route' => 'settings',
+        'route' => 'profile.settings',
     ],
     [
         'title' => 'Activity Log',
         'icon' => 'list',
-        'route' => 'activity-logs',
+        'route' => 'profile.logs',
     ],
 ]" />

--- a/resources/views/components/layout/employee/nav/main-menu.blade.php
+++ b/resources/views/components/layout/employee/nav/main-menu.blade.php
@@ -73,12 +73,12 @@
                             onerror="this.onerror=null;this.src='http://placehold.it/45/45';" alt="">
                     </button>
                     <ul id="dropdown-menu" class="dropdown-menu dropdown-menu-end px-2" role="menu">
-                        <a href="{{ route($routePrefix . '.profile') }}" class="text-decoration-none">
+                        <a href="{{ route($routePrefix . '.profile.index') }}" class="text-decoration-none">
                             <li class="dropdown-item" role="button">
                                 Profile
                             </li>
                         </a>
-                        <a href="{{ route($routePrefix . '.settings') }}" class="text-decoration-none">
+                        <a href="{{ route($routePrefix . '.profile.settings') }}" class="text-decoration-none">
                             <li class="dropdown-item" role="button" class="mt-5">Settings & Privacy</li>
                         </a>
                         <a href="{{ route($routePrefix . '.recycle-bin') }}" class="text-decoration-none">

--- a/resources/views/employee/hr-manager/employees/information.blade.php
+++ b/resources/views/employee/hr-manager/employees/information.blade.php
@@ -10,9 +10,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 @endsection
 
-@pushOnce('pre-scripts')
-@endPushOnce
-
 @pushOnce('scripts')
     @vite(['resources/js/employee/hr-manager/employee-info.js'])
     @vite(['resources/js/employee/calendar.js'])
@@ -21,6 +18,7 @@
 @pushOnce('styles')
     @vite(['resources/css/employee/hr-manager/employee-info.css'])
 @endPushOnce
+
 @section('content')
     <x-breadcrumbs>
         <x-slot:breadcrumbs>

--- a/resources/views/employee/profile/information/index.blade.php
+++ b/resources/views/employee/profile/information/index.blade.php
@@ -8,7 +8,7 @@
 @endsection
 
 @pushOnce('scripts')
-    @vite(['resources/js/employee/hr/dashboard.js'])
+    @vite(['resources/js/employee/hr-manager/dashboard.js'])
 @endPushOnce
 
 @pushOnce('styles')
@@ -28,114 +28,14 @@
 
     <div class="col-md-4 text-end d-flex justify-content-end align-items-center">
         <div>
-            <!-- BACK-END REPLACE: Replace with Employee ID while redirecting to Edit Profile -->
             <a href="{{ route($routePrefix . '.profile.edit') }}" class="btn btn-lg btn-outline-primary">
                 <i data-lucide="pen-line" class="icon icon-large me-2"></i>
-                Edit Profile
+                {{ __('Edit Profile') }}
             </a>
         </div>
     </div>
 </div>
 
-<!-- BACK-END REPLACE Note:
+<livewire:profile.information />
 
-This section can be replaced with the same component used in Employees' in HR Manager: information.
-The only thing I removed was the Date Hired, but that can be bring up again if you think it's needed. -->
-
-<section>
-    <div class="row">
-        <!-- Left Column: Work / Personal Information -->
-        <div class="col-md-6">
-            <!-- SECTION: Image & Name, Job Title, Level -->
-            <section class="text-center">
-                <!-- BACK-END REPLACE: Replace with Default Avatar / Employee photo -->
-                <img class="img-size-30 img-responsive rounded-circle w-100 h-auto object-fit-cover aspect-ratio--square"
-                    src="https://ui-avatars.com/api/?name=Blackwell+Kelly" alt="">
-
-                <div class="pt-2">
-                    <!-- BACK-END REPLACE: Name, Job Title, Level -->
-                    <p class="fw-bold fs-3">Blackwell, Kelly Princess J.</p>
-                    <p class="fs-5">Associate / Assistant Manager</p>
-                    <p class="fs-6 fw-normal text-primary">Level 2: Associate</p>
-                </div>
-            </section>
-
-            <!-- SECTION: Work Details -->
-            <section class="pt-4 px-4">
-                <div>
-                    <!-- BACK-END REPLACE: Department, Employment Status, Shift, Hired Date -->
-                    <p class="pb-2"><b>Department:</b> Human Resources</p>
-                    <p class="pb-2"><b>Supervisor:</b> Anika M. Laurel</p>
-                    <p class="pb-2"><b>Employment Status:</b> Regular</p>
-                    <p class="pb-2"><b>Shift:</b> Day Shift</p>
-                </div>
-
-                <div class="mt-3">
-                    <x-headings.section-title title="{{ __('Personal Details') }}" />
-
-                    <!-- BACK-END REPLACE: Birthday, Sex, Cvil Status, Educational Attaintment -->
-                    <p class="pt-2 pb-2"><b>Birthdate:</b> December 29, 1998</p>
-                    <p class="pb-2"><b>Sex at birth:</b> Female</p>
-                    <p class="pb-2"><b>Civil Status:</b> Married</p>
-                    <p class="pb-2"><b>Educational Attainment:</b> College</p>
-                </div>
-
-            </section>
-        </div>
-
-        <!-- Right Column: Contact, Address, IDs -->
-        <div class="col-md-6">
-
-            <!-- SECTION: Contact Information -->
-            <section class="row">
-                <div class="col mb-3">
-                    <div class="card bg-body-secondary border-0 py-4 px-5">
-                        <x-headings.section-title title="{{ __('Contact Information') }}" />
-
-                        <div class="px-2">
-                            <!-- BACK-END REPLACE: Email, Contact Number -->
-                            <p class="pt-3 pb-2"><b>Email:</b> blackwell.kpj@gmail.com</p>
-                            <p class="pb-2"><b>Contact Number:</b> +63 912 345 6789</p>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <!-- SECTION: Addresses -->
-            <section class="row">
-                <div class="col mb-3">
-                    <div class="card bg-body-secondary border-0 py-4 px-5">
-                        <x-headings.section-title title="{{ __('Addresses') }}" />
-
-                        <div class="px-2">
-                            <!-- BACK-END REPLACE: Preset & Permanent Address -->
-                            <p class="pt-3 pb-2"><b>Present Address:</b> Block 7, Lot 14, Barangay Mabuhay, Taguig City,
-                                Metro Manila</p>
-                            <p class="pb-2"><b>Permanent Address:</b> Block 15, Lot 7, Barangay Moonwalk, Parañaque
-                                City, Metro Manila</p>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <!-- SECTION: Identification Numbers -->
-            <section class="row">
-                <div class="col mb-3">
-                    <div class="card bg-body-secondary border-0 py-4 px-5">
-                        <x-headings.section-title title="{{ __('Identification Numbers') }}" />
-
-                        <div class="px-2">
-                            <!-- BACK-END REPLACE: SSS, Cedula/CTC, PhilHealth, TIN, Pag-IBIG -->
-                            <p class="pt-3 pb-2"><b>SSS:</b> 43-1294876-1</p>
-                            <p class="pb-2"><b>Cedula/CTC: </b> 87654321</p>
-                            <p class="pb-2"><b>PhilHealth: </b> 11-234567890-3</p>
-                            <p class="pb-2"><b>TIN: </b> 954-672-809-321</p>
-                            <p class="pb-2"><b>Pag-IBIG: </b> 987654321098</p>
-                        </div>
-                    </div>
-                </div>
-            </section>
-        </div>
-    </div>
-</section>
 @endsection

--- a/resources/views/livewire/profile/information.blade.php
+++ b/resources/views/livewire/profile/information.blade.php
@@ -1,0 +1,149 @@
+<section>
+    <style>
+        .left-col {
+            display: grid;
+            grid-template-columns: 130px 1fr;
+            column-gap: 20px;
+            row-gap:5px;
+        }
+
+        .right-col {
+            display: grid;
+            grid-template-columns: max-content 1fr;
+            column-gap: 20px;
+            row-gap: 5px;
+        }
+    </style>
+    
+    <div class="row">
+        <!-- Left Column: Work / Personal Information -->
+        <div class="col-md-6">
+            <!-- SECTION: Image & Name, Job Title, Level -->
+            <section class="text-center">
+                <img class="img-size-30 img-responsive rounded-circle w-100 h-auto object-fit-cover aspect-ratio--square"
+                    src="{{ $employee->photo }}" alt="">
+
+                <div class="pt-2">
+                    <p class="fw-bold fs-3">{{ $employee->name }}</p>
+                    <p class="fs-5">{{ $employee->jobTitle }}</p>
+                    <p class="fs-6 fw-medium text-primary">{{ "Level {$employee->jobLevel}: {$employee->jobLevelName}" }}</p>
+                </div>
+            </section>
+
+            <!-- SECTION: Work Details -->
+            <section class="pt-4 px-4">
+                <div class="d-flex align-items-center">
+                    <i class="icon icon-slarge text-primary me-2" data-lucide="briefcase-business"></i>
+                    <x-headings.section-title title="{{ __('Work Information') }}" />
+                </div>              
+
+                <div class="left-col pt-2 align-items-center">
+                    <div class="fw-bold">{{ __('Job Family: ') }}</div>
+                    <p>{{ $employee->jobFamily }}</p>
+                    <div class="fw-bold">{{ __('Supervisor:  ') }}</div>
+                    <p>Supervisor Name here</p>
+                    <div class="fw-bold">{{ __('Employment Status: ') }}</div>
+                    <p>{{ $employee->employmentStatus }}</p>
+                    <div class="fw-bold">{{ __('Shift Schedule: ') }}</div>
+                    <p>{{ $employee->shift.' ('.$employee->shiftSched.')' }}</p>
+                    <div class="fw-bold">{{ __('Date Hired: ') }}</div>
+                    <p>{{ $employee->hiredAt ?? __('No record found.') }}</p>
+                </div>
+
+                <div class="mt-3">
+                    <div class="d-flex align-items-center">
+                        <i class="icon icon-slarge text-primary me-2" data-lucide="user-cog"></i>
+                        <x-headings.section-title title="{{ __('Personal Information') }}" />
+                    </div>
+                    <div class="pt-2 left-col align-items-center">
+                        <div class="fw-bold">{{ __('Date of Birth: ') }}</div>
+                        <p>{{ \Illuminate\Support\Carbon::make($employee->dob)->format('F d, Y') ?? __('Not provided') }}</p>
+                        <div class="fw-bold">{{ __('Sex: ') }}</div>
+                        <p>{{ $employee->sex }}</p>
+                        <div class="fw-bold">{{ __('Civil Status: ') }}</div>
+                        <p>{{ $employee->civilStatus }}</p>
+                    </div>
+                </div>
+
+            </section>
+        </div>
+
+        <!-- Right Column: Contact, Address, IDs -->
+        <div class="col-md-6">
+
+            <!-- SECTION: Contact Information -->
+            <section class="row">
+                <div class="col mb-3">
+                    <div class="card bg-body-secondary border-0 py-4 px-5 text-secondary-emphasis">
+                        <div class="d-flex align-items-center">
+                            <i class="icon icon-slarge text-primary me-2" data-lucide="send"></i>
+                            <x-headings.section-title title="{{ __('Contact Information') }}" />
+                        </div>
+
+                        <div class="right-col pt-3 px-2">
+                            <div class="fw-bold">{{ __('Email Address: ') }}</div>
+                            <a class="text-decoration-none" href="mailto:{{ $employee->email }}">{{ $employee->email }}</a>
+                            <div class="fw-bold">{{ __('Contact No: ') }}</div>
+                            <a class="text-decoration-none" href="tel:{{ $employee->contactNo }}">{{ $employee->contactNo }}</a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- SECTION: Addresses -->
+            <section class="row">
+                <div class="col mb-3">
+                    <div class="card bg-body-secondary border-0 py-4 px-5 text-secondary-emphasis">
+                        <div class="d-flex align-items-center">
+                            <i class="icon icon-slarge text-primary me-2" data-lucide="map-pin"></i>
+                            <x-headings.section-title title="{{ __('Address') }}" />
+                        </div>
+
+                        <div class="right-col px-2 pt-3">
+                            <div class="fw-bold">{{ __('Present: ') }}</div>
+                            <p>{{ $employee->fullPresentAddress }}</p>
+                            <div class="fw-bold">{{ __('Permanent: ') }}</div>
+                            <p>{{ $employee->fullPermanentAddress }}</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- SECTION: Identification Numbers -->
+            <section class="row">
+                <div class="col mb-3">
+                    <div class="card bg-body-secondary border-0 py-4 px-5 text-secondary-emphasis">
+                        <div class="d-flex align-items-center">
+                            <i class="icon icon-slarge text-primary me-2" data-lucide="id-card"></i>
+                            <x-headings.section-title title="{{ __('Mandatory Contribution Ids') }}" />
+                        </div>
+
+                        <div class="right-col pt-3 px-2 align-items-center">
+                            <div class="fw-bold">{{ __('SS Number: ') }}</div>
+                            <p>{{ $employee->sss }}</p>
+                            <div class="fw-bold">{{ __('PhilHealth ID No: ') }}</div>
+                            <p>{{ $employee->philHealth }}</p>
+                            <div class="fw-bold">{{ __('Taxpayer ID No: ') }}</div>
+                            <p>{{ $employee->tin }}</p>
+                            <div class="fw-bold">{{ __('Pag-IBIG MID No: ') }}</div>
+                            <p>{{ $employee->pagIbig }}</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <div class="row">
+                <div class="col d-flex align-items-center justify-content-end">
+                    <div class="hover-opacity pe-auto">
+                        <!-- BACK-END REPLACE: Link to the current employee's profile -->
+                        <a href="#" id="toggle-documents" class="text-link-blue text-decoration-underline fs-5">
+                            View Documents
+                        </a>
+
+                        <i data-lucide="arrow-right" class="icon icon-slarge ms-2 text-blue-info"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/routes/employee.php
+++ b/routes/employee.php
@@ -60,7 +60,7 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
         return view('employee.notifications.index');
     })->name('notifications');
 
-    
+
     /**
      * Organization
      */
@@ -504,7 +504,7 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
         return view('employee.hr-manager.employees.information', compact('employee'));
     })
         ->whereNumber('employee')
-        ->name('employees.masterlist.information');
+        ->name('employees.information');
 
 
     /**
@@ -552,11 +552,11 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
      * Archive
      */
     Route::get('/archive', function () {
-        return view('/employee.hr-manager.archive.index');
+        return view('employee.hr-manager.archive.index');
     })->name('employees.archive');
 
     Route::get('/archive/records', function () {
-        return view('/employee.hr-manager.archive.records');
+        return view('employee.hr-manager.archive.records');
     })->name('employees.archive.records');
 
 

--- a/routes/employee.php
+++ b/routes/employee.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ProfileController;
 use App\Models\Employee;
 use App\Enums\UserPermission;
 use Illuminate\Support\Facades\Route;
@@ -25,32 +26,24 @@ Route::middleware('guest')->group(function () {
 });
 
 Route::middleware('auth'/* , 'verified' */)->group(function () {
-
-    // =========================================
-    // ALL USER ROUTES
-    // ==========================================
-
+    
     /**
-     * Profile
+     * Profile Resource
      */
-    Route::get('profile', function () {
-        return view('employee.profile.information.index');
-    })->name('profile');
+    Route::prefix('profile')->name('profile.')->group(function () {
+        Route::get('/', [ProfileController::class, 'index'])
+            ->name('index');
 
-    Route::get('profile/edit', function () {
-        return view('employee.profile.information.edit');
-    })->name('profile.edit');
+        Route::get('edit', [ProfileController::class, 'edit'])
+            ->name('edit');
 
-    /**
-     * Settings & Privacy
-     */
-    Route::get('settings', function () {
-        return view('employee.profile.settings');
-    })->name('settings');
+        Route::get('settings', [ProfileController::class, 'settings'])
+            ->name('settings');
 
-    Route::get('activity-logs', function () {
-        return view('employee.profile.activity-logs');
-    })->name('activity-logs');
+        Route::get('activity-logs', [ProfileController::class, 'logs'])
+            ->name('logs');
+    });
+
 
     /**
      * Recycle Bin
@@ -67,11 +60,7 @@ Route::middleware('auth'/* , 'verified' */)->group(function () {
         return view('employee.notifications.index');
     })->name('notifications');
 
-
-    // =========================================
-    // HR MANAGER ROUTES
-    // ==========================================
-
+    
     /**
      * Organization
      */


### PR DESCRIPTION
### 🛠 Changes

- Cache employee information to reduce performance overhead on database operations. This drastically reduce the needs to query employee information everytime `/profile` or `/employee` information is accessed.

without cache

![image](https://github.com/user-attachments/assets/6bcd24bf-9abc-4ed0-a0dc-d9f0e08aa1fe)


with cache

![image](https://github.com/user-attachments/assets/8113f0eb-170b-4bf2-b18e-1e4b04f332a1)

- As you can see, the elapsed time is drastically reduced for like 4x from `466ms` to `82.02ms` and the select queries is cut more than half from `26` to `12`. Latency went from `1.46s` to `454ms`

### ✔️ Checklist

- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
