### PR TITLE
refactor: daily time records / attendance logs

### DIFF
--- a/app/Http/Helpers/BiometricDevice.php
+++ b/app/Http/Helpers/BiometricDevice.php
@@ -255,4 +255,9 @@ class BiometricDevice
             return Str::of($params[0])->chopStart('~')->trim()->toString();
         }
     }
+
+    public function clearAttendanceLogs()
+    {
+        $this->zk->clearAttendance();
+    }
 }

--- a/app/Livewire/Admin/Dashboard/DailyTimeRecord.php
+++ b/app/Livewire/Admin/Dashboard/DailyTimeRecord.php
@@ -3,142 +3,34 @@
 namespace App\Livewire\Admin\Dashboard;
 
 use Livewire\Component;
-use App\Models\AttendanceLog;
-use Illuminate\Support\Carbon;
+use App\Traits\AttendanceUtils;
 use Livewire\Attributes\Locked;
-use App\Enums\BiometricPunchType;
-use Illuminate\Support\Collection;
-use App\Http\Helpers\BiometricDevice;
+use App\Services\AttendanceService;
 
 class DailyTimeRecord extends Component
 {
+    use AttendanceUtils;
+
+    private $attendanceService;
+
     #[Locked]
-    public $dateToday;
+    public $dtrLogs;
 
-    private BiometricDevice $zkInstance;
+    #[Locked]
+    public $totalDtr;
 
-    public function mount()
+    public function boot(AttendanceService $attendanceService)
     {
-        $this->dateToday = Carbon::today();
-    }
+        $this->attendanceService = $attendanceService;
 
-    // always uncomment if need demo for checkin
-    // public function boot()
-    // {
-    //     $this->zkInstance = new BiometricDevice();
-    // }
+        // $this->attendanceService->storeDtrLogs(); // uncomment if bio machine is connected
 
-    private function getTodayDtr()
-    {   
-        $this->upsertTodayDtr();
-
-        return AttendanceLog::whereDate('timestamp', $this->dateToday)
-            ->with(['employee', 'employee.account'])
-            // ->orderByDesc('timestamp')
-            ->get()
-            ->groupBy('employee_id')
-            ->map(function ($group) {
-                $type = $this->getPunchesTime($group);
-                $punch = $group->first();
-                $employee = $punch->employee;
-
-                return (object) [
-                    'uid' => $punch->uid,
-                    'state' => $punch->state,
-                    'checkIn' => $type->checkIn,
-                    'checkOut' => $type->checkOut,
-                    'employee' => optional($employee, function ($puncher) {
-                        return (object) [
-                            'id' => $puncher->employee_id,
-                            'name' => $puncher->full_name,
-                            'photo' => $puncher->account->photo,
-                        ];
-                    }),
-                ];
-            });
-    }
-
-    private function upsertTodayDtr()
-    {
-        $this->zkInstance->getRawAttendanceLogs()
-            ->filter(fn ($log) => Carbon::parse($log->timestamp)->isSameDay($this->dateToday))
-            ->each(function ($item) {
-                AttendanceLog::upsert([
-                    'uid' => $item->uid,
-                    'employee_id' => (int) $item->id,
-                    'state' => $item->state,
-                    'type' => $item->type,
-                    'timestamp' => $item->timestamp
-                ],
-                uniqueBy: ['uid'], 
-                update: [
-                    'employee_id',
-                    'state',
-                    'timestamp',
-                    'type',
-                ]);
-            });
-    }
-
-    private function getPunchesTime(Collection $group)
-    {
-        return $group->reduce(function ($carry, $log) {
-            $time = Carbon::parse($log->timestamp)->format('g:i A');
-
-            if (in_array($log->type, [
-                BiometricPunchType::OVERTIME_IN->value,
-                BiometricPunchType::OVERTIME_OUT->value,
-            ])) {
-                return $carry;
-            }    
-
-            match ($log->type) {
-                BiometricPunchType::CHECK_IN->value => $carry->checkIn = $time,
-                BiometricPunchType::CHECK_OUT->value => $carry->checkOut = $time,
-            };
-
-            return $carry;
-        }, (object) [
-            'checkIn' => null,
-            'checkOut' => null,
-        ]);
-    }
-
-    private function generateFakeData()
-    {
-        return AttendanceLog::with(['employee', 'employee.account'])
-            ->get()
-            ->groupBy('employee_id')
-            ->map(function ($group) {
-                $type = $this->getPunchesTime($group);
-                $punch = $group->first();
-                $employee = $punch->employee;
-
-                return (object) [
-                    'uid' => $punch->uid,
-                    'state' => $punch->state,
-                    'checkIn' => $type->checkIn,
-                    'checkOut' => $type->checkOut,
-                    'employee' => optional($employee, function ($puncher) {
-                        return (object) [
-                            'id' => $puncher->employee_id,
-                            'name' => $puncher->full_name,
-                            'photo' => $puncher->account->photo,
-                        ];
-                    }),
-                ];
-            });
+        $this->dtrLogs = $this->attendanceService->getDtrLogs();
+        $this->totalDtr = $this->dtrLogs->count();
     }
 
     public function render()
     {
-        // $dtrLogs = $this->getTodayDtr();
-        // $totalDtr = $dtrLogs->count();
-        $dtrLogs = $this->generateFakeData();
-        $totalDtr = $dtrLogs->count();
-        
-        return view('livewire.admin.dashboard.daily-time-record', [
-            'dtrDate' => $this->dateToday->format('F, d Y')
-        ], compact('dtrLogs', 'totalDtr'));
+        return view('livewire.admin.dashboard.daily-time-record');
     }
 }

--- a/app/Livewire/Employee/Tables/IndividualEmployeeOvertimesTable.php
+++ b/app/Livewire/Employee/Tables/IndividualEmployeeOvertimesTable.php
@@ -101,12 +101,12 @@ class IndividualEmployeeOvertimesTable extends DataTableComponent
                 ->sortable()
                 ->deselected(),
             
-            Column::make(__('Date Requested'), 'date')
-                ->format(fn ($row) => Carbon::parse($row)->format('F d, Y'))
-                ->sortable()
-                ->searchable()
-                ->setSortingPillDirections('Asc', 'Desc')
-                ->setSortingPillTitle(__('Request Date')),
+            // Column::make(__('Date Requested'), 'date')
+            //     ->format(fn ($row) => Carbon::parse($row)->format('F d, Y'))
+            //     ->sortable()
+            //     ->searchable()
+            //     ->setSortingPillDirections('Asc', 'Desc')
+            //     ->setSortingPillTitle(__('Request Date')),
             
             Column::make(__('Hours Requested'))
                 ->label(fn ($row) => $row->hoursRequested)

--- a/app/Livewire/Tables/EmployeesAttendanceTable.php
+++ b/app/Livewire/Tables/EmployeesAttendanceTable.php
@@ -115,7 +115,7 @@ class EmployeesAttendanceTable extends DataTableComponent
 
     public function configure(): void
     {
-        $this->setPrimaryKey('application_id');
+        $this->setPrimaryKey('employee_id');
         $this->enableAllEvents();
 
         $this->configuringStandardTableMethods();
@@ -170,7 +170,7 @@ class EmployeesAttendanceTable extends DataTableComponent
                     ->latest('timestamp')
                     ->take(1),
             ])
-            ->orderBy('latest_timestamp', 'desc')
+            ->orderBy('latest_timestamp', 'asc')
             ->with([
                 'jobDetail',
                 'account',

--- a/app/Models/AttendanceLog.php
+++ b/app/Models/AttendanceLog.php
@@ -2,22 +2,18 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class AttendanceLog extends Model
 {
     use HasFactory;
 
     public $timestamps = false;
-    
-    public $incrementing = false;
-
-    protected $primaryKey = 'uid';
 
     protected $fillable = [
-        'uid',
         'employee_id',
         'state',
         'type',
@@ -28,6 +24,19 @@ class AttendanceLog extends Model
         'timestamp' => 'datetime',
     ];
 
+    /**
+     * Scope query builder to get timestamp for today's date.
+     */
+    public function scopeToday(Builder $query)
+    {
+        $query->whereDate('timestamp', today());
+    }
+
+    /**
+     * Get the employee that owns the attendance log.
+     * 
+     * @return BelongsTo<Employee, AttendanceLog>
+     */
     public function employee(): BelongsTo
     {
         return $this->belongsTo(Employee::class, 'employee_id', 'employee_id');

--- a/app/Models/EmployeeLeave.php
+++ b/app/Models/EmployeeLeave.php
@@ -17,7 +17,6 @@ class EmployeeLeave extends Model
 
     const UPDATED_AT = 'modified_at';
 
-
     protected $primaryKey = 'emp_leave_id';
 
     protected $guarded = [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Enums\UserRole;
 use App\Policies\EmployeeArchivePolicy;
 use App\Policies\IssuePolicy;
 use App\Policies\TrainingPolicy;
+use App\Services\AttendanceService;
 use App\Services\PayrollSummaryService;
 use Illuminate\Support\Carbon;
 use App\Policies\ContractPolicy;
@@ -17,7 +18,6 @@ use Laravel\Pulse\Facades\Pulse;
 use App\Policies\UserStatusPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Vite;
-use App\Http\Helpers\BiometricDevice;
 use App\Policies\EmployeeLeavePolicy;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
@@ -43,14 +43,14 @@ class AppServiceProvider extends ServiceProvider
          */
         $this->app->register(ComposerServiceProvider::class);
 
-        $this->app->singleton(BiometricDevice::class, function () {
-            return new BiometricDevice();
-        });
-
         $this->app->register(FormWizardServiceProvider::class);
 
         $this->app->bind(PayrollSummaryService::class, function () {
             return new PayrollSummaryService();
+        });
+
+        $this->app->bind(AttendanceService::class, function () {
+            return new AttendanceService();
         });
     }
 

--- a/app/Services/AttendanceService.php
+++ b/app/Services/AttendanceService.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceLog;
+use Illuminate\Support\Carbon;
+use App\Traits\AttendanceUtils;
+use Illuminate\Support\Facades\DB;
+use App\Http\Helpers\BiometricDevice;
+use Illuminate\Database\Eloquent\Collection;
+
+class AttendanceService
+{
+    use AttendanceUtils;
+
+    public $storedDtrLogs;
+
+    /**
+     * Create a new instance.
+     */
+    public function __construct()
+    {
+        $this->storedDtrLogs = AttendanceLog::today()->get();
+    }
+
+    /**
+     * Store Daily Time Record Logs
+     * 
+     * Get raw attendance logs from the ZKTeco bio machine, validate for duplicate check-ins and 
+     * check-outs for each employee, and store it in `attendance_logs` table.
+     * 
+     * @return void
+     */
+    public function storeDtrLogs(): void
+    {
+        $zkInstance = new BiometricDevice;
+
+        $todayLogs = $zkInstance->getRawAttendanceLogs()
+            ->filter(fn ($log) => Carbon::parse($log->timestamp)->isSameDay(today()))
+            ->sortBy('timestamp');
+
+        if ($todayLogs->isEmpty()) return;
+
+        $newLogs = collect([]);
+
+        foreach ($todayLogs as $todayLog) {
+            $contains = $newLogs->contains(function ($log) use ($todayLog) {
+                return 
+                    (int) $todayLog->id === $log['employee_id'] &&
+                    $todayLog->type === $log['type'];
+            });
+
+            $exists = $this->storedDtrLogs->where('employee_id', (int) $todayLog->id)
+                                        ->where('type', $todayLog->type)
+                                        ->first();
+
+            if ($contains || $exists) continue;
+
+            $newLogs->push([
+                'employee_id'   => (int) $todayLog->id,
+                'state'         => $todayLog->state,
+                'type'          => $todayLog->type,
+                'timestamp'     => $todayLog->timestamp  
+            ]);
+        }
+
+        if ($newLogs->isNotEmpty()) {
+            DB::transaction(fn () => AttendanceLog::insert($newLogs->toArray()));
+        }
+    }
+
+    /**
+     * Get daily time record logs for today only.
+     * 
+     * @return Collection<int|string, object>
+     */
+    public function getDtrLogs()
+    {
+        return AttendanceLog::today()->with([
+            'employee',
+            'employee.account',
+        ])
+            ->get()
+            ->groupBy('employee_id')
+            ->map(function ($group) {
+                $type = $this->getPunchesTime($group);
+                $punch = $group->first();
+                $employee = $punch->employee;
+
+                return (object) [
+                    'checkIn' => $type->checkIn,
+                    'checkOut' => $type->checkOut,
+                    'employee' => optional($employee, function ($puncher) {
+                        return (object) [
+                            'id' => $puncher->employee_id,
+                            'name' => $puncher->full_name,
+                            'photo' => $puncher->account->photo,
+                        ];
+                    }),
+                ];
+            });
+    }
+
+    public function clearDtrLogs()
+    {
+        $zkInstance = new BiometricDevice;
+
+        $zkInstance->clearAttendanceLogs();
+    }
+}

--- a/app/Traits/AttendanceUtils.php
+++ b/app/Traits/AttendanceUtils.php
@@ -128,4 +128,21 @@ trait AttendanceUtils
             return (float) "{$hours}.{$mins}";
         }
     }
+
+    public function getPunchesTime(Collection $group)
+    {
+        return $group->reduce(function ($carry, $log) {
+            $time = Carbon::parse($log->timestamp)->format('g:i A');
+
+            match ($log->type) {
+                BiometricPunchType::CHECK_IN->value => $carry->checkIn = $time,
+                BiometricPunchType::CHECK_OUT->value => $carry->checkOut = $time,
+            };
+
+            return $carry;
+        }, (object) [
+            'checkIn' => null,
+            'checkOut' => null,
+        ]);
+    }
 }

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -11,7 +11,7 @@ return [
      * When the clean-command is executed, all recording activities older than
      * the number of days specified here will be deleted.
      */
-    'delete_records_older_than_days' => 365,
+    'delete_records_older_than_days' => 1825,
 
     /*
      * If no log name is passed to the activity() helper

--- a/database/migrations/2024_11_30_130241_create_attendance_logs_table.php
+++ b/database/migrations/2024_11_30_130241_create_attendance_logs_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('attendance_logs', function (Blueprint $table) {
-            $table->id('uid');
+            $table->id();
             $table->foreignIdFor(Employee::class, 'employee_id')
                 ->constrained('employees', 'employee_id')
                 ->cascadeOnUpdate()

--- a/database/seeders/AttendanceLogSeeder.php
+++ b/database/seeders/AttendanceLogSeeder.php
@@ -30,35 +30,15 @@ class AttendanceLogSeeder extends Seeder
                 ];
                 
                 for ($i = 2; $i > 0; $i--) {
-                    array_push($this->mockData, [
-                        'uid'           => $this->generateUniqueUid(),
+                    $this->mockData[] = [
                         'employee_id'   => $employee->employee_id,
                         'state'         => fake()->numberBetween(1, 9),
                         'type'          => $i === 2 ? $checkIn['type'] : $checkOut['type'],
-                        'timestamp'     => $i === 2 ? $checkIn['timestamp'] : $checkOut['timestamp'],
-                    ]);
+                        'timestamp'     => $i === 2 ? $checkIn['timestamp'] : $checkOut['timestamp'],                        
+                    ];
                 }
             });
-        
-        // dd($this->mockData);
 
         DB::table('attendance_logs')->insert($this->mockData);
-    }
-
-    /**
-     * Generate a unique UID that doesn't conflict with existing uids.
-     *
-     * @return int
-     */
-    private function generateUniqueUid(): int
-    {
-        $uid = fake()->unique()->randomNumber();
-        
-        while (AttendanceLog::where('uid', $uid)->exists() || 
-            in_array($uid, array_values($this->mockData))) {
-            $uid = fake()->unique()->randomNumber();
-        }
-
-        return $uid;
     }
 }

--- a/resources/views/livewire/admin/dashboard/daily-time-record.blade.php
+++ b/resources/views/livewire/admin/dashboard/daily-time-record.blade.php
@@ -10,7 +10,7 @@
                 <header class="fs-4 fw-bold text-secondary-emphasis">
                     {{ __('Daily Time Record') }}
                 </header>
-                <div class="text-muted">{{ $dtrDate }}</div>
+                <div class="text-muted">{{ today()->format('F d, Y') }}</div>
             </div>
             {{-- Refresh Button --}}
             <div wire:ignore class="ms-auto">
@@ -33,24 +33,27 @@
                 </thead>
 
                 <tbody>
-                    @foreach ($dtrLogs as $dtrLog)
-                        <tr class="px-5">
-                            <td class="d-flex align-items-center px-4 py-3">
-                                <img src="{{ $dtrLog->employee->photo }}" alt="User Picture" width="45" height="45"
-                                    class="rounded-circle me-3">
-                                <div>
-                                    <div>{{ $dtrLog->employee->name ?? __('Unknown Employee') }}</div>
-                                    <small class="text-muted">
-                                        <span class="fw-bold">{{ __('Employee Id:') }}</span>
-                                        {{ $dtrLog->employee->id }}
-                                    </small>
-                                </div>
-                            </td>
-                            <td class="text-center">{{ $dtrLog->checkIn ?? '-' }}</td>
-                            <td class="text-center">{{ $dtrLog->checkOut ?? '-' }}</td>
-                        </tr>
-                    @endforeach
-
+                    @if ($dtrLogs->isEmpty())
+                        {{-- some empty state here --}}
+                    @else
+                        @foreach ($dtrLogs as $dtrLog)
+                            <tr class="px-5">
+                                <td class="d-flex align-items-center px-4 py-3">
+                                    <img src="{{ $dtrLog->employee->photo }}" alt="User Picture" width="45" height="45"
+                                        class="rounded-circle me-3">
+                                    <div>
+                                        <div>{{ $dtrLog->employee->name ?? __('Unknown Employee') }}</div>
+                                        <small class="text-muted">
+                                            <span class="fw-bold">{{ __('Employee Id:') }}</span>
+                                            {{ $dtrLog->employee->id }}
+                                        </small>
+                                    </div>
+                                </td>
+                                <td class="text-center">{{ $dtrLog->checkIn ?? '-' }}</td>
+                                <td class="text-center">{{ $dtrLog->checkOut ?? '-' }}</td>
+                            </tr>
+                        @endforeach                    
+                    @endif
                 </tbody>
             </table>
         </div>

--- a/resources/views/livewire/employee/attendance/sync-dtr-logs.blade.php
+++ b/resources/views/livewire/employee/attendance/sync-dtr-logs.blade.php
@@ -1,10 +1,10 @@
 <div>
     <div class="d-flex column-gap-2 column-gap-lg-3">
-        <form wire:submit="sync" class="d-contents">
-            <button class="btn btn-primary fw-light py-2 rounded-5">
+        <div class="d-contents">
+            <button wire:click="$refresh" class="btn btn-primary fw-light py-2 rounded-5">
                 <i class="icon icon-large mx-2" data-lucide="refresh-cw"></i>
                 {{ __('Refresh DTR Logs') }}
             </button>
-        </form>
+        </div>
     </div>
 </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,28 +6,33 @@ use Illuminate\Support\Facades\Schedule;
  * To-dos
  * 
  * Command that execute every January 1 to reset the leave balance of every employee to 10(default).
- * Command that clears the activity log. I don't know if this should be set annually to execute.
  * Command that executes daily to backup the database.
- * Command that generates the payroll summary for payroll_summaries table
  * Command that executes daily to remove applicants who are rejected for more or exactly than 30 days.
  */
 
 Schedule::daily()
+    ->withoutOverlapping()
     ->timezone('Asia/Manila')
     ->group(function () {
-        Schedule::command('sync-attlogs-from-biometric-device'); // to revisit implementation
+        Schedule::command('sync-attlogs-from-biometric-device');
         Schedule::command('check-probationary-evaluation-period-opening');
         Schedule::command('check-payroll-period-opening');
         Schedule::command('delete-separated-employee-data');
         Schedule::command('generate-payroll-summary');
+        Schedule::command('activitylog:clean');
     }
 );
 
 // for debugging
 // Schedule::everyFiveSeconds()
+//     ->withoutOverlapping()
 //     ->timezone('Asia/Manila')
 //     ->group(function () {
-//         Schedule::command('check-payroll-period-opening');
-//         Schedule::command('generate-payroll-summary');
+//         // Schedule::command('sync-attlogs-from-biometric-device');
+//         // Schedule::command('check-probationary-evaluation-period-opening');
+//         // Schedule::command('check-payroll-period-opening');
+//         // Schedule::command('delete-separated-employee-data');
+//         // Schedule::command('generate-payroll-summary');
+//         // Schedule::command('activitylog:clean');
 //     }
 // );


### PR DESCRIPTION
### 🛠 Changes

- Used service container for interacting with the `AttendanceLog` model and its methods.
- The implementation was refactored to ensure duplication-free entry of logs in the `attendance_logs` table.
- Refresh the migration for this table only to save you from headache of running a fresh one:
```
php artisan refresh --path=database/migrations/2024_11_30_130241_create_attendance_logs_table.php
```
- Added the task scheduler that executes daily for activity logs to cleanup older records. set initially from 365(1 yr) to 1825(5 yrs). Just to be consistent with their data retention period.

### ✔️ Checklist

- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
