### PR TITLE
fix: evaluation period routing issue

### DIFF
--- a/app/Enums/PerformanceEvaluationPeriod.php
+++ b/app/Enums/PerformanceEvaluationPeriod.php
@@ -28,4 +28,13 @@ enum PerformanceEvaluationPeriod: string
             self::ANNUAL => 'Annual',
         };
     }
+
+    public static function options(): array
+    {
+        return array_reduce(
+            self::cases(),
+            fn ($options, $case) => $options + [$case->value => $case->getLabel()],
+            []
+        );
+    }
 }

--- a/app/Enums/StatusBadge.php
+++ b/app/Enums/StatusBadge.php
@@ -7,13 +7,17 @@ enum StatusBadge: string
     case APPROVED = 'approved';
     case DENIED = 'denied';
     case PENDING = 'pending';
+    case INVALID = 'invalid';
+    case INCOMPLETE = 'incomplete';
 
     public function getColor()
     {
         return match ($this) {
             self::APPROVED => 'success',
-            self::DENIED => 'danger',
-            self::PENDING => 'info'
+            self::DENIED,
+            self::INVALID => 'danger',
+            self::PENDING => 'info',
+            self::INCOMPLETE => 'warning',
         };
     }
 
@@ -22,7 +26,9 @@ enum StatusBadge: string
         return match ($this) {
             self::APPROVED => __('APPROVED'),
             self::DENIED => __('DENIED'),
+            self::INVALID => __('INVALID'),
             self::PENDING => __('PENDING'),
+            self::INCOMPLETE => __('INCOMPLETE'),
         };
     }
 }

--- a/app/Livewire/Employee/Tables/AnyRegularsPerformancesTable.php
+++ b/app/Livewire/Employee/Tables/AnyRegularsPerformancesTable.php
@@ -74,16 +74,14 @@ class AnyRegularsPerformancesTable extends DataTableComponent
     public function builder(): Builder
     {
         return Employee::query()
+            ->ofEmploymentStatus(EmploymentStatus::REGULAR)
             ->with([
                 'account:account_type,account_id,photo',
                 'performancesAsRegular' => [
                     'categoryRatings' => ['rating'],
                 ],
             ])
-            ->whereNot('employee_id', Auth::user()->account->employee_id) // not sure abt this
-            ->whereHas('status', function ($query) {
-                $query->where('emp_status_name', EmploymentStatus::REGULAR->label());
-            })
+            // ->whereNot('employee_id', Auth::user()->account->employee_id) // not sure abt this
             ->where(function ($query) {
                 $query->whereHas('performancesAsRegular', function ($sq) {
                     $sq->whereNotNull('secondary_approver_signed_at');

--- a/app/Livewire/Employee/Tables/AnyRegularsPerformancesTable.php
+++ b/app/Livewire/Employee/Tables/AnyRegularsPerformancesTable.php
@@ -2,109 +2,100 @@
 
 namespace App\Livewire\Employee\Tables;
 
+use App\Livewire\Tables\Defaults;
 use App\Models\Employee;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use App\Enums\StatusBadge;
 use App\Enums\EmploymentStatus;
 use Livewire\Attributes\Locked;
 use Illuminate\Support\Facades\Auth;
 use App\Models\RegularPerformancePeriod;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\View\ComponentAttributeBag;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class AnyRegularsPerformancesTable extends DataTableComponent
 {
+    use Defaults;
+
     protected $model = Employee::class;
 
     #[Locked]
     public $routePrefix;
 
+    private $periodOptions;
+
+    private $performance;
+
+    private $period;
+
     public function configure(): void
     {
-        $this->setPrimaryKey('employee_id')
-            ->setTableRowUrl(fn ($row) => route("{$this->routePrefix}.performances.regulars.review", [
-                'performance' => $row->performancesAsRegular->first()->regular_performance_id,
-            ]  ))
-
-            ->setTableRowUrlTarget(fn () => '__blank');
+        $this->setPrimaryKey('employee_id');
         $this->setPageName('any-regulars-performance');
-        $this->setEagerLoadAllRelationsEnabled();
+        $this->setDefaultSortingLabels('Lowest', 'Highest');
         $this->setSingleSortingDisabled();
-        $this->enableAllEvents();
-        $this->setQueryStringEnabled();
-        $this->setOfflineIndicatorEnabled();
-        // $this->setDefaultSort('filed_at', 'desc');
-        $this->setSearchDebounce(1000);
-        $this->setTrimSearchStringEnabled();
-        $this->setEmptyMessage(__('No results found.'));
-        $this->setPerPageAccepted([10, 25, 50, 100, -1]);
-        $this->setToolBarAttributes(['class' => ' d-md-flex my-md-2']);
-        $this->setToolsAttributes(['class' => ' bg-body-secondary border-0 rounded-3 px-5 py-2']);
         $this->setRememberColumnSelectionDisabled();
+        $this->configuringStandardTableMethods();
 
+        $this->periodOptions = $this->getPeriodOptions();
+        
         $this->setTableAttributes([
             'default' => true,
-            'class' => 'table-hover px-1 no-transition',
+            'class' => 'px-1 no-transition',
         ]);
-
-        $this->setTrAttributes(function ($row, $index) {
-            return [
-                'default' => true,
-                'class' => 'border-1 rounded-2 outline no-transition mx-4',
-            ];
-        });
-
-        $this->setSearchFieldAttributes([
-            'type' => 'search',
-            'class' => 'form-control rounded-3 search text-body body-bg shadow-sm',
-        ]);
-
-        $this->setThAttributes(function (Column $column) {
-            return [
-                'default' => true,
-                'class' => 'text-center fw-medium',
-            ];
-        });
-
-        $this->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex) {
-            return [
-                'class' => $column->getTitle() === 'Evaluatee' ? 'text-md-start' :'text-md-center',
-            ];
-        });
 
         $this->setConfigurableAreas([
             'toolbar-left-start' => [
-                'components.headings.main-heading',
+                'components.table.filter.select-filter',
                 [
-                    'overrideClass' => true,
-                    'overrideContainerClass' => true,
-                    'attributes' => new ComponentAttributeBag([
-                        'class' => 'fs-5 py-1 text-secondary-emphasis fw-medium text-underline',
-                    ]),
-                    'heading' => __('Current Period: ').now()->format('F d, Y'),
+                    'filter' => (function () {
+                        return SelectFilter::make(__('Evaluation Period'), 'evalPeriod')
+                            ->options($this->periodOptions)
+                            ->filter(function (Builder $query, $value) {
+                                $this->dispatch('setFilter', 'evalPeriod', $value);
+                            });
+                    })(),
+
+                    'label' => __('Evaluation Period: ')
                 ],
             ],
         ]);
+
+        $this->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex) {
+            $this->performance = $row->performancesAsRegular->firstWhere('period_id', $this->period);
+
+            return [
+                'class' => $column->getTitle() === 'Evaluatee' ? 'text-md-start border-end sticky' :'text-md-center',
+            ];
+        });
     }
 
     public function builder(): Builder
     {
         return Employee::query()
             ->with([
-                'account',
-                'performancesAsRegular',
-                'performancesAsRegular.period',
-                'performancesAsRegular.categoryRatings.rating',
+                'account:account_type,account_id,photo',
+                'performancesAsRegular' => [
+                    'categoryRatings' => ['rating'],
+                ],
             ])
-            ->whereNot('employee_id', Auth::user()->account->employee_id)
-            ->whereHas('jobDetail.status', function ($query) {
+            ->whereNot('employee_id', Auth::user()->account->employee_id) // not sure abt this
+            ->whereHas('status', function ($query) {
                 $query->where('emp_status_name', EmploymentStatus::REGULAR->label());
             })
-            ->whereHas('performancesAsRegular', function ($query) {
-                $query->whereNotNull('secondary_approver_signed_at');
+            ->where(function ($query) {
+                $query->whereHas('performancesAsRegular', function ($sq) {
+                    $sq->whereNotNull('secondary_approver_signed_at');
+                });
+                
+                $query->orWhere(function ($sq) {
+                    $sq->whereHas('jobTitle.jobFamily', function ($ssq) {
+                        $ssq->where('job_family_id', Auth::user()->account->jobTitle->jobFamily->job_family_id);
+                    })->whereHas('performancesAsRegular', function ($ssq) {
+                        $ssq->whereNotNull('evaluator_signed_at');
+                    });
+                });
             });
     }
 
@@ -112,76 +103,75 @@ class AnyRegularsPerformancesTable extends DataTableComponent
     {
         return [
             Column::make(__('Evaluatee'))
-                ->label(function ($row) {
-                    $name = Str::headline($row->full_name);
-                    $photo = $row->account->photo;
-                    $id = $row->employee_id;
-
-                    return '<div class="d-flex align-items-center">
-                                <img src="' . e($photo) . '" alt="User Picture" class="rounded-circle me-3" style="width: 38px; height: 38px;">
-                                <div>
-                                    <div>' . e($name) . '</div>
-                                    <div class="text-muted fs-6">Employee ID: ' . e($id) . '</div>
-                                </div>
-                            </div>';
-                })
-                ->html()
+                ->label(fn ($row) => view('components.table.employee')->with([
+                        'name'  => $row->full_name,
+                        'photo' => $row->account->photo,
+                        'id'    => $row->employee_id,
+                    ])
+                )
                 ->sortable(fn (Builder $query, $direction) => $query->orderBy('last_name' ,$direction))
-                ->searchable(function (Builder $query, $searchTerm) {
-                    return $query->whereLike('first_name', "%{$searchTerm}%")
-                        ->orWhereLike('middle_name', "%{$searchTerm}%")
-                        ->orWhereLike('last_name', "%{$searchTerm}%");
-                }),
+                ->searchable(fn (Builder $query, $searchTerm) => $this->applyFullNameSearch($query, $searchTerm))
+                ->setSortingPillDirections('A-Z', 'Z-A'),
 
-            Column::make(__('Status'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        return __('Completed');
-                    } else {
-                        return __('Incomplete');
-                    }
-                }),
+            Column::make(__('Completion'))
+                ->label(function () {            
+                    $url = route("{$this->routePrefix}.performances.regulars.show", [
+                        'performance' => $this->performance->regular_performance_id,
+                    ]);
+                    
+                    return "<a href='{$url}' class='btn btn-info btn-md justify-content-center w-auto'>
+                                <i data-lucide='eye' class='icon icon-large me-1'></i>
+                                <span class='fw-light'>Review Evaluation</span>
+                            </a>";
+                })
+                ->html(),
 
-            Column::make(__('Results'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        if ($row->performancesAsRegular->first()->fourth_approver_signed_at) {
-                            return __('Approved');
-                        } else {
-                            return __('Pending');
+            Column::make(__('Approval'))
+                ->label(function () {
+                    $badge = [
+                        'color' => StatusBadge::PENDING->getColor(),
+                        'slot' => StatusBadge::PENDING->getLabel(),
+                    ];
+    
+                    if ($this->performance) {
+                        if ($this->performance->fourth_approver_signed_at) {
+                            $badge = [
+                                'color' => StatusBadge::APPROVED->getColor(),
+                                'slot' => StatusBadge::APPROVED->getLabel(),
+                            ];
                         }
-                    } else {
-                        return '-';
+                        return view('components.status-badge')->with($badge);
                     }
+
+                    return '--';
                 }),
 
             Column::make(__('Final Rating'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        $finalRating = $row->performancesAsRegular->first()->final_rating;
-                        return $finalRating['ratingAvg'];
-                    } else {
-                        return '-';
-                    }
-                }),
+                ->label(function () {
+                    if ($this->performance) {
+                        $finalRating = $this->performance->final_rating;
 
-            Column::make(__('Performance Scale'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        $finalRating = $row->performancesAsRegular->first()->final_rating;
-                        return $finalRating['performanceScale'];
-                    } else {
-                        return '-';
+                        return sprintf(
+                            '%s - %s',
+                            $finalRating['ratingAvg'],
+                            $finalRating['performanceScale']
+                        );
                     }
+
+                    return '--';
                 }),
 
             Column::make(__('Period'))
-                ->label(function ($row) {
-                    if (is_null($row->performancesAsRegular->first())) {
-                        return ' - ';
-                    } else {
-                        return $row->performancesAsRegular->first()->period->interval;
-                    }
+                ->label(function () {
+                    $period = array_filter(
+                        $this->periodOptions,
+                        fn ($option) => $option == $this->period
+                            ? $this->periodOptions[$option]
+                            : null, 
+                        ARRAY_FILTER_USE_KEY
+                    );
+
+                    return $period ? array_values($period)[0] : '--';
                 }),
         ];
     }
@@ -189,26 +179,70 @@ class AnyRegularsPerformancesTable extends DataTableComponent
     public function filters(): array
     {
         return [
-            SelectFilter::make(__('Evaluation Period'))
-                ->options($this->getPeriodOptions())
+            SelectFilter::make(__('Evaluation Period'), 'evalPeriod')
+                ->options($this->periodOptions)
                 ->filter(function (Builder $query, $value) {
-                    return $query->whereHas('performancesAsRegular.period', function ($subQuery) use ($value) {
-                        $subQuery->where('period_id', $value);
+                    $query->where(function ($sq) use ($value) {
+                        $sq->whereHas('performancesAsRegular', 
+                            fn ($ssq) => $ssq->where('period_id', $value)
+                        );                        
+                    });
+
+                    $this->period = (int) $value;
+                })
+                ->notResetByClearButton()
+                ->setFilterPillTitle('Period')
+                ->setFilterDefaultValue(array_key_first($this->periodOptions))
+                ->hiddenFromMenus(),
+
+            SelectFilter::make(__('Completion'))
+                ->options([
+                    '' => __('Select Completion Status'),
+                    '0' => __('Incomplete'),
+                    '1' => __('Completed'),
+                ])
+                ->filter(function (Builder $query, $value) {
+                    if ($value === '0') {
+                        $query->whereDoesntHave(
+                            'performancesAsRegular', 
+                            fn ($sq) => $sq->where('period_id', $this->period)
+                        );
+                    } elseif ($value === '1') {
+                        $query->whereHas(
+                            'performancesAsRegular', 
+                            fn ($sq) => $sq->where('period_id', $this->period)
+                        );                        
+                    }
+                })
+                ->setFilterDefaultValue(''),
+
+            SelectFilter::make(__('Approval'))
+                ->options([
+                    '' => __('Select Approval Status'),
+                    '0' => __('Pending'),
+                    '1' => __('Approved'),
+                ])
+                ->filter(function (Builder $query, $value) {
+                    $query->whereHas('performancesAsRegular', function ($sq) use ($value) {
+                        $sq->where('period_id', $this->period);
+                        
+                        if ($value === '0') {
+                            $sq->whereNull('fourth_approver_signed_at');
+                        } elseif ($value === '1') {
+                            $sq->whereNotNull('fourth_approver_signed_at');
+                        }
                     });
                 })
-                ->setFilterPillTitle('Period')
-                // ->setFilterDefaultValue(RegularPerformancePeriod::latest()->first()->period_id)
+                ->setFilterDefaultValue(''),
         ];
     }
+
     private function getPeriodOptions(): array
     {
-        return RegularPerformancePeriod::all()
-            ->mapWithKeys(function ($item) {
-                $start = Carbon::make($item->start_date)->format('j M, Y');
-                $end = Carbon::make($item->end_date)->format('j M Y');
-                $period = "{$start} - {$end}";
-
-                return [$item->period_id => $period];
+        return RegularPerformancePeriod::orderByDesc('start_date')
+            ->get()
+            ->mapWithKeys(function ($period) {
+                return [$period->period_id => $period->interval];
             })->toArray();
     }
 }

--- a/app/Livewire/Employee/Tables/ProbationarySubordinatesPerformancesTable.php
+++ b/app/Livewire/Employee/Tables/ProbationarySubordinatesPerformancesTable.php
@@ -3,148 +3,110 @@
 namespace App\Livewire\Employee\Tables;
 
 use App\Models\Employee;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use App\Enums\StatusBadge;
 use App\Enums\EmploymentStatus;
 use Livewire\Attributes\Locked;
+use App\Livewire\Tables\Defaults;
 use App\Models\PerformanceRating;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Builder;
 use App\Enums\PerformanceEvaluationPeriod;
-use Illuminate\View\ComponentAttributeBag;
-use App\Models\ProbationaryPerformancePeriod;
+use Illuminate\Database\Eloquent\Collection;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class ProbationarySubordinatesPerformancesTable extends DataTableComponent
 {
+    use Defaults;
+
     protected $model = Employee::class;
 
     #[Locked]
     public $routePrefix;
 
+    private $isFinal;
+
+    private $currentPeriod;
+
+    private $performances;
+
+    private $periodOptions;
+
+    private $periodFilter;
+
     public function configure(): void
     {
-        $this->setPrimaryKey('employee_id')
-            ->setTableRowUrl(fn ($row) => $this->setRoute($row))
-            ->setTableRowUrlTarget(fn () => '__blank');
+        $this->setPrimaryKey('employee_id');
         $this->setPageName('probationary-subordinates-performance');
-        $this->setEagerLoadAllRelationsEnabled();
+        $this->setDefaultSortingLabels('Lowest', 'Highest');
         $this->setSingleSortingDisabled();
-        $this->enableAllEvents();
-        $this->setQueryStringEnabled();
-        $this->setOfflineIndicatorEnabled();
-        // $this->setDefaultSort('filed_at', 'desc');
-        $this->setSearchDebounce(1000);
-        $this->setTrimSearchStringEnabled();
-        $this->setEmptyMessage(__('No results found.'));
-        $this->setPerPageAccepted([10, 25, 50, 100, -1]);
-        $this->setToolBarAttributes(['class' => ' d-md-flex my-md-2']);
-        $this->setToolsAttributes(['class' => ' bg-body-secondary border-0 rounded-3 px-5 py-2']);
         $this->setRememberColumnSelectionDisabled();
+        $this->configuringStandardTableMethods();
+
+        $this->periodOptions = $this->getPeriodOptions();
 
         $this->setTableAttributes([
             'default' => true,
-            'class' => 'table-hover px-1 no-transition',
+            'class' => 'px-1 no-transition',
         ]);
-
-        $this->setTrAttributes(function ($row, $index) {
-            return [
-                'default' => true,
-                'class' => 'border-1 rounded-2 outline no-transition mx-4',
-            ];
-        });
-
-        $this->setSearchFieldAttributes([
-            'type' => 'search',
-            'class' => 'form-control rounded-3 search text-body body-bg shadow-sm',
-        ]);
-
-        $this->setThAttributes(function (Column $column) {
-            return [
-                'default' => true,
-                'class' => 'text-center fw-medium',
-            ];
-        });
-
-        $this->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex) {
-            return [
-                'class' => $column->getTitle() === 'Evaluatee' ? 'text-md-start' :'text-md-center',
-            ];
-        });
 
         $this->setConfigurableAreas([
             'toolbar-left-start' => [
-                'components.headings.main-heading',
+                'components.table.filter.select-filter',
                 [
-                    'overrideClass' => true,
-                    'overrideContainerClass' => true,
-                    'attributes' => new ComponentAttributeBag([
-                        'class' => 'fs-5 py-1 text-secondary-emphasis fw-medium text-underline',
-                    ]),
-                    'heading' => __('Current Period: ').now()->format('F d, Y'),
+                    'filter' => (function () {
+                        return SelectFilter::make(__('Type'))
+                            ->options($this->periodOptions)
+                            ->filter(function (Builder $query, $value) {
+                                $this->dispatch('setFilter', 'type', $value);
+                            });
+                    })(),
+
+                    'label' => __('Stage Type: ')
                 ],
             ],
         ]);
-    }
 
-    private function setRoute(Employee $employee)
-    {   
-        $evaluation = $employee->performancesAsProbationary;
-
-        if ($this->isProbationaryFinalEvaluated($evaluation)) {
-            session()->put('final_rating', 
-                $this->computeFinalRating($evaluation),
-            );
-
-            return route("{$this->routePrefix}.performances.probationaries.show", [
-                'employee' => $employee->employee_id,
-                'year_period' => Carbon::parse($evaluation->last()->end_date)->year,
-            ]);
-        } else {
-            return route("{$this->routePrefix}.performances.probationaries.create", [
-                'employee' => $employee->employee_id,
-            ]);
-        }
+        $this->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex) {
+            $this->performances = $row->performancesAsProbationary
+                ->when($this->periodFilter, fn ($query) => $query->where('period_name', $this->periodFilter));
+            $this->isFinal = $this->isFinalEvaluated($this->performances);
+            $this->currentPeriod = $this->performances->sortByDesc('end_date')->first();
+                
+            return [
+                'class' => $columnIndex === 0 ? 'text-md-start border-end sticky' : 'text-md-center',
+            ];
+        });
     }
 
     public function builder(): Builder
     {
         return Employee::query()
+            ->ofEmploymentStatus(EmploymentStatus::PROBATIONARY)
             ->with([
-                'account',
-                'performancesAsProbationary',
-                'performancesAsProbationary.details',
-                'performancesAsProbationary.details.categoryRatings.rating',
+                'account:account_type,account_id,photo',
+                'performancesAsProbationary' => [
+                    'details' => [
+                        'categoryRatings' => ['rating'],
+                    ],
+                ],
             ])
             ->whereNot('employee_id', Auth::user()->account->employee_id)
-            ->whereHas('jobDetail.status', function ($query) {
-                $query->where('emp_status_name', EmploymentStatus::PROBATIONARY->label());
-            })
             ->whereHas('jobTitle.jobFamily', function ($query) {
                 $query->where('job_family_id', Auth::user()->account->jobTitle->jobFamily->job_family_id);
             })
-            ->whereHas('performancesAsProbationary', function ($query) {
-                $query->where('start_date', '<=', now())
-                      ->where(function ($subQuery) {
-                          $subQuery->where('end_date', '>=', now());
-                      });
-            });;
+            ->whereHas('performancesAsProbationary');
     }
 
-    private function isProbationaryFinalEvaluated($evaluations)
+    private function isFinalEvaluated(Collection $evaluations): bool|null
     {
         $final = $evaluations->filter(function ($item) {
             return $item->period_name === PerformanceEvaluationPeriod::FINAL_MONTH->value;
-        });
+        })->first();
 
-        if (! $final->isNotEmpty()) {
-            return false;
-        }
-
-        return $final->first()->details->isNotEmpty();
+        return $final?->details?->isNotEmpty();
     }
 
     private function computeFinalRating($performanceCollection)
@@ -186,104 +148,133 @@ class ProbationarySubordinatesPerformancesTable extends DataTableComponent
     {
         return [
             Column::make(__('Evaluatee'))
-                ->label(function ($row) {
-                    $name = Str::headline($row->full_name);
-                    $photo = $row->account->photo;
-                    $id = $row->employee_id;
-            
-                    return '<div class="d-flex align-items-center">
-                                <img src="' . e($photo) . '" alt="User Picture" class="rounded-circle me-3" style="width: 38px; height: 38px;">
-                                <div>
-                                    <div>' . e($name) . '</div>
-                                    <div class="text-muted fs-6">Employee ID: ' . e($id) . '</div>
-                                </div>
-                            </div>';
-                })
-                ->html()
-                ->sortable(fn (Builder $query, $direction) => $query->orderBy('last_name' ,$direction))
-                ->searchable(function (Builder $query, $searchTerm) {
-                    return $query->whereLike('first_name', "%{$searchTerm}%")
-                        ->orWhereLike('middle_name', "%{$searchTerm}%")
-                        ->orWhereLike('last_name', "%{$searchTerm}%");
-                }),
-            
-            Column::make(__('Status'))
-                ->label(function ($row) {
-                    if ($this->isProbationaryFinalEvaluated($row->performancesAsProbationary)) {
-                        return __('Completed');
-                    } else {
-                        return __('Incomplete');
-                    }
-                }),
+                ->label(fn ($row) => view('components.table.employee')->with([
+                    'name'  => $row->full_name,
+                    'photo' => $row->account->photo,
+                    'id'    => $row->employee_id
+                ]))
+                ->sortable(fn (Builder $query, $direction) => $query->orderBy('last_name', $direction))
+                ->searchable(fn (Builder $query, $searchTerm) => $this->applyFullNameSearch($query, $searchTerm)),
 
-            Column::make(__('Results'))
+            Column::make(__('Stage Type'))
+                ->label(fn () => PerformanceEvaluationPeriod::from($this->currentPeriod->period_name)->getLabel()),
+
+            Column::make(__('Completion'))
                 ->label(function ($row) {
-                    if ($this->isProbationaryFinalEvaluated($row->performancesAsProbationary)) {
-                        if ($row->performancesAsProbationary->last()->details->last()->fourth_approver_signed_at) {
-                            return __('Approved');
-                        } else {
-                            return __('Pending');
-                        }
-                    } else {
-                        return '-';
+                    $evaluations = $row->performancesAsProbationary;
+
+                    if ($this->isFinal) {
+                        session()->put('final_rating', $this->computeFinalRating($evaluations));
+                
+                        $url = route("{$this->routePrefix}.performances.probationaries.show", [
+                            'employee' => $row->employee_id,
+                            'year_period' => $evaluations->max('end_date')->year,
+                        ]);
+
+                        return "<a href='{$url}' class='btn btn-info btn-sm justify-content-center w-auto'>
+                                    <i data-lucide='eye' class='icon icon-large me-1'></i>
+                                    <span class='fw-light'>Review Evaluation</span>
+                                </a>";
                     }
+
+                    $url = route("{$this->routePrefix}.performances.probationaries.create", [
+                        'employee' => $row->employee_id,
+                    ]);
+
+                    if ($evaluations->contains(fn ($evaluation) => 
+                        $evaluation->details->contains('period_id', $this->currentPeriod->period_id))
+                    ) {
+                        return "<a href='{$url}' class='btn btn-info btn-sm justify-content-center w-auto'>
+                                    <i data-lucide='eye' class='icon icon-large me-1'></i>
+                                    <span class='fw-light'>Review Evaluation</span>
+                                </a>";                            
+                    }
+                        
+                    if ($evaluations->max('end_date')->ne($this->currentPeriod->end_date)) {
+                        return view('components.status-badge')->with([
+                            'color' => StatusBadge::INVALID->getColor(),
+                            'slot' => __('Not Applicable')
+                        ]);
+                    }
+
+                    return "<a href='{$url}' class='btn btn-primary btn-sm justify-content-center w-auto'>
+                                <i data-lucide='pen' class='icon icon-medium me-1'></i>
+                                <span class='fw-light'>Start Evaluation</span>
+                            </a>";
+                })
+                ->html(),
+
+            Column::make(__('Approval'))
+                ->label(function ($row) {
+                    $badge = [
+                        'color' => StatusBadge::PENDING->getColor(),
+                        'slot' => StatusBadge::PENDING->getLabel(),
+                    ];
+
+                    if ($this->isFinal) {
+                        $isFullyApproved = $this->performances->first(function ($performance) {
+                            return $performance->period_name === PerformanceEvaluationPeriod::FINAL_MONTH->value;
+                        })->details->first(fn ($detail) => $detail->fourth_approver_signed_at);
+
+                        if ($isFullyApproved) {
+                            $badge = [
+                                'color' => StatusBadge::APPROVED->getColor(),
+                                'slot' => StatusBadge::APPROVED->getLabel(),
+                            ];
+                        }
+
+                        return view('components.status-badge')->with($badge);
+                    }
+
+                    return '--';
                 }),
 
             Column::make(__('Final Rating'))
                 ->label(function ($row) {
-                    if ($this->isProbationaryFinalEvaluated($row->performancesAsProbationary)) {
-                        $finalRating = $this->computeFinalRating($row->performancesAsProbationary);
-                        return $finalRating['format'];
-                    } else {
-                        return '-';
-                    }
-                }),
+                    if ($this->isFinal) {
+                        $finalRating = $this->computeFinalRating($this->performances); 
 
-            Column::make(__('Performance Scale'))
-                ->label(function ($row) {
-                    if ($this->isProbationaryFinalEvaluated($row->performancesAsProbationary)) {
-                        $finalRating = $this->computeFinalRating($row->performancesAsProbationary);
-                        return $finalRating['scale'];
-                    } else {
-                        return '-';
+                        return sprintf(
+                            "<strong>%s - %s</strong>",
+                            $finalRating['format'],
+                            $finalRating['scale']
+                        );
                     }
-                }),
 
-            // Column::make(__('Period'))
-            //     ->label(function ($row) {
-            //         if ($this->isProbationaryFinalEvaluated($row->performancesAsProbationary)) {
-            //             return $row->performancesAsProbationary->details->last()->period->interval;
-            //         } else {
-            //             return '-';
-            //         }
-            //     }),
+                    return '--';
+                })
+                ->html(),
+
+            Column::make(__('Period'))->label(fn () => $this->currentPeriod->interval),
         ];
     }
 
     public function filters(): array
     {
         return [
-            SelectFilter::make(__('Evaluation Period'))
-                ->options($this->getPeriodOptions())
+            SelectFilter::make(__('Type'))
+                ->options($this->periodOptions)
                 ->filter(function (Builder $query, $value) {
-                    return $query->whereHas('performancesAsProbationary.period', function ($subQuery) use ($value) {
-                        $subQuery->where('period_id', $value);
+                    $query->whereHas('performancesAsProbationary', function ($subQuery) use ($value) {
+                        $subQuery->where('period_name', $value);
                     });
+                    
+                    $this->periodFilter = $value;
                 })
-                ->setFilterPillTitle('Period')
-                // ->setFilterDefaultValue(RegularPerformancePeriod::latest()->first()->period_id)
+                ->setFilterPillTitle('Type')
+                ->hiddenFromMenus()
+                ->hiddenFromFilterCount(),
         ];
     }
     
     private function getPeriodOptions(): array
     {
-        return ProbationaryPerformancePeriod::all()
-            ->mapWithKeys(function ($item) {
-                $start = Carbon::make($item->start_date)->format('j M, Y');
-                $end = Carbon::make($item->end_date)->format('j M Y');
-                $period = "{$start} - {$end}";
+        $filtered = array_filter(
+            PerformanceEvaluationPeriod::options(), 
+            fn ($option) => $option != PerformanceEvaluationPeriod::ANNUAL->value, 
+            ARRAY_FILTER_USE_KEY
+        );
 
-                return [$item->period_id => $period];
-            })->toArray();
+        return ['' => __('Select a type')] + $filtered;
     }
 }

--- a/app/Livewire/Employee/Tables/RegularSubordinatesPerformancesTable.php
+++ b/app/Livewire/Employee/Tables/RegularSubordinatesPerformancesTable.php
@@ -80,6 +80,7 @@ class RegularSubordinatesPerformancesTable extends DataTableComponent
     public function builder(): Builder
     {
         return Employee::query()
+            ->ofEmploymentStatus(EmploymentStatus::REGULAR)
             ->with([
                 'account:account_type,account_id,photo',
                 'performancesAsRegular' => [
@@ -87,9 +88,6 @@ class RegularSubordinatesPerformancesTable extends DataTableComponent
                 ],
             ])
             ->whereNot('employee_id', Auth::user()->account->employee_id)
-            ->whereHas('status', function ($query) {
-                $query->where('emp_status_name', EmploymentStatus::REGULAR->label());
-            })
             ->whereHas('jobTitle.jobFamily', function ($query) {
                 $query->where('job_family_id', Auth::user()->account->jobTitle->jobFamily->job_family_id);
             });
@@ -164,14 +162,15 @@ class RegularSubordinatesPerformancesTable extends DataTableComponent
                         $finalRating = $this->performance->final_rating;
 
                         return sprintf(
-                            '%s - %s',
+                            "<strong>%s - %s</strong>",
                             $finalRating['ratingAvg'],
                             $finalRating['performanceScale']
                         );
                     }
 
                     return '--';
-                }),
+                })
+                ->html(),
 
             Column::make(__('Period'))
                 ->label(function () {

--- a/app/Livewire/Employee/Tables/RegularSubordinatesPerformancesTable.php
+++ b/app/Livewire/Employee/Tables/RegularSubordinatesPerformancesTable.php
@@ -3,115 +3,91 @@
 namespace App\Livewire\Employee\Tables;
 
 use App\Models\Employee;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
+use App\Enums\StatusBadge;
 use App\Enums\EmploymentStatus;
 use Livewire\Attributes\Locked;
+use App\Livewire\Tables\Defaults;
 use App\Models\RegularPerformance;
 use Illuminate\Support\Facades\Auth;
 use App\Models\RegularPerformancePeriod;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\View\ComponentAttributeBag;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class RegularSubordinatesPerformancesTable extends DataTableComponent
 {
+    use Defaults;
+
     protected $model = RegularPerformance::class;
 
     #[Locked]
     public $routePrefix;
 
+    private $periodOptions;
+
+    private $period;
+
+    private $performance;
+
+    private $isEvaluatable;
+
     public function configure(): void
     {
-        $this->setPrimaryKey('regular_performance_id')
-            ->setTableRowUrl(fn ($row) => $this->setRoute($row))
-            ->setTableRowUrlTarget(fn () => '__blank');
+        $this->setPrimaryKey('regular_performance_id');
         $this->setPageName('regular-subordinates-performance');
-        $this->setEagerLoadAllRelationsEnabled();
+        $this->setDefaultSortingLabels('Lowest', 'Highest');
         $this->setSingleSortingDisabled();
-        $this->enableAllEvents();
-        $this->setQueryStringEnabled();
-        $this->setOfflineIndicatorEnabled();
-        // $this->setDefaultSort('filed_at', 'desc');
-        $this->setSearchDebounce(1000);
-        $this->setTrimSearchStringEnabled();
-        $this->setEmptyMessage(__('No results found.'));
-        $this->setPerPageAccepted([10, 25, 50, 100, -1]);
-        $this->setToolBarAttributes(['class' => ' d-md-flex my-md-2']);
-        $this->setToolsAttributes(['class' => ' bg-body-secondary border-0 rounded-3 px-5 py-2']);
         $this->setRememberColumnSelectionDisabled();
 
-        $this->setTableAttributes([
-            'default' => true,
-            'class' => 'table-hover px-1 no-transition',
-        ]);
+        $this->periodOptions = $this->getPeriodOptions();
 
-        $this->setTrAttributes(function ($row, $index) {
-            return [
-                'default' => true,
-                'class' => 'border-1 rounded-2 outline no-transition mx-4',
-            ];
-        });
-
-        $this->setSearchFieldAttributes([
-            'type' => 'search',
-            'class' => 'form-control rounded-3 search text-body body-bg shadow-sm',
-        ]);
-
-        $this->setThAttributes(function (Column $column) {
-            return [
-                'default' => true,
-                'class' => 'text-center fw-medium',
-            ];
-        });
-
-        $this->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex) {
-            return [
-                'class' => $column->getTitle() === 'Evaluatee' ? 'text-md-start' :'text-md-center',
-            ];
-        });
+        $this->configuringStandardTableMethods();
 
         $this->setConfigurableAreas([
             'toolbar-left-start' => [
-                'components.headings.main-heading',
+                'components.table.filter.select-filter',
                 [
-                    'overrideClass' => true,
-                    'overrideContainerClass' => true,
-                    'attributes' => new ComponentAttributeBag([
-                        'class' => 'fs-5 py-1 text-secondary-emphasis fw-medium text-underline',
-                    ]),
-                    'heading' => __('Current Period: ').now()->format('F d, Y'),
+                    'filter' => (function () {
+                        return SelectFilter::make(__('Evaluation Period'), 'evalPeriod')
+                            ->options($this->periodOptions)
+                            ->filter(function (Builder $query, $value) {
+                                $this->dispatch('setFilter', 'evalPeriod', $value);
+                            });
+                            // ->setFirstOption('Current');
+                    })(),
+
+                    'label' => __('Evaluation Period: ')
                 ],
             ],
         ]);
-    }
 
-    private function setRoute(Employee $employee)
-    {   
-        if ($employee->performancesAsRegular->first()) {
-            return route("{$this->routePrefix}.performances.regulars.show", [
-                'performance' => $employee->performancesAsRegular->first()->regular_performance_id
-            ]);
-        } else {
-            return route("{$this->routePrefix}.performances.regulars.create", [
-                'employee' => $employee->employee_id
-            ]);
-        }
+        $this->setTableAttributes([
+            'default' => true,
+            'class' => 'px-1 no-transition',
+        ]);
+
+        $this->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex) {
+            $this->performance = $row->performancesAsRegular->firstWhere('period_id', $this->period);
+            $this->isEvaluatable = array_key_first($this->periodOptions) === $this->period && ! $this->performance;
+
+            return [
+                'class' => $column->getTitle() === 'Evaluatee' ? 'text-start border-end sticky' : 'text-center',
+            ];
+        });
     }
 
     public function builder(): Builder
     {
         return Employee::query()
             ->with([
-                'account',
-                'performancesAsRegular',
-                'performancesAsRegular.period',
-                'performancesAsRegular.categoryRatings.rating',
+                'account:account_type,account_id,photo',
+                'performancesAsRegular' => [
+                    'categoryRatings' => ['rating'],
+                ],
             ])
             ->whereNot('employee_id', Auth::user()->account->employee_id)
-            ->whereHas('jobDetail.status', function ($query) {
+            ->whereHas('status', function ($query) {
                 $query->where('emp_status_name', EmploymentStatus::REGULAR->label());
             })
             ->whereHas('jobTitle.jobFamily', function ($query) {
@@ -123,76 +99,91 @@ class RegularSubordinatesPerformancesTable extends DataTableComponent
     {
         return [
             Column::make(__('Evaluatee'))
-                ->label(function ($row) {
-                    $name = Str::headline($row->full_name);
-                    $photo = $row->account->photo;
-                    $id = $row->employee_id;
-            
-                    return '<div class="d-flex align-items-center">
-                                <img src="' . e($photo) . '" alt="User Picture" class="rounded-circle me-3" style="width: 38px; height: 38px;">
-                                <div>
-                                    <div>' . e($name) . '</div>
-                                    <div class="text-muted fs-6">Employee ID: ' . e($id) . '</div>
-                                </div>
-                            </div>';
-                })
-                ->html()
+                ->label(fn ($row) => view('components.table.employee')->with([
+                        'name'  => $row->full_name,
+                        'photo' => $row->account->photo,
+                        'id'    => $row->employee_id,
+                    ])
+                )
                 ->sortable(fn (Builder $query, $direction) => $query->orderBy('last_name' ,$direction))
-                ->searchable(function (Builder $query, $searchTerm) {
-                    return $query->whereLike('first_name', "%{$searchTerm}%")
-                        ->orWhereLike('middle_name', "%{$searchTerm}%")
-                        ->orWhereLike('last_name', "%{$searchTerm}%");
-                }),
+                ->searchable(fn (Builder $query, $searchTerm) => $this->applyFullNameSearch($query, $searchTerm))
+                ->setSortingPillDirections('A-Z', 'Z-A'),
             
-            Column::make(__('Status'))
+            Column::make(__('Completion'))
                 ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        return __('Completed');
-                    } else {
-                        return __('Incomplete');
+                    if ($this->isEvaluatable) {
+                        $url = route("{$this->routePrefix}.performances.regulars.create", [
+                            'employee' => $row->employee_id,
+                        ]);
+                        return "<a href='{$url}' class='btn btn-primary btn-md justify-content-center w-auto'>
+                                    <i data-lucide='pen' class='icon icon-medium me-1'></i>
+                                    <span class='fw-light'>Start Evaluation</span>
+                                </a>";
                     }
-                }),
+            
+                    if (! $this->performance) {
+                        return view('components.status-badge')->with([
+                            'color' => StatusBadge::INVALID->getColor(),
+                            'slot' => __('Not Applicable')
+                        ]);
+                    }
+            
+                    $url = route("{$this->routePrefix}.performances.regulars.show", [
+                        'performance' => $this->performance->regular_performance_id,
+                    ]);
+                    return "<a href='{$url}' class='btn btn-info btn-md justify-content-center w-auto'>
+                                <i data-lucide='eye' class='icon icon-large me-1'></i>
+                                <span class='fw-light'>Review Evaluation</span>
+                            </a>";
+                })
+                ->html(),
 
-            Column::make(__('Results'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        if ($row->performancesAsRegular->first()->fourth_approver_signed_at) {
-                            return __('Approved');
-                        } else {
-                            return __('Pending');
+            Column::make(__('Approval'))
+                ->label(function () {
+                    $badge = [
+                        'color' => StatusBadge::PENDING->getColor(),
+                        'slot' => StatusBadge::PENDING->getLabel(),
+                    ];
+    
+                    if ($this->performance) {
+                        if ($this->performance->fourth_approver_signed_at) {
+                            $badge = [
+                                'color' => StatusBadge::APPROVED->getColor(),
+                                'slot' => StatusBadge::APPROVED->getLabel(),
+                            ];
                         }
-                    } else {
-                        return '-';
+                        return view('components.status-badge')->with($badge);
                     }
+
+                    return '--';
                 }),
 
             Column::make(__('Final Rating'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        $finalRating = $row->performancesAsRegular->first()->final_rating;  
-                        return $finalRating['ratingAvg'];
-                    } else {
-                        return '-';
-                    }
-                }),
+                ->label(function () {
+                    if ($this->performance) {
+                        $finalRating = $this->performance->final_rating;
 
-            Column::make(__('Performance Scale'))
-                ->label(function ($row) {
-                    if ($row->performancesAsRegular->first()) {
-                        $finalRating = $row->performancesAsRegular->first()->final_rating;  
-                        return $finalRating['performanceScale'];
-                    } else {
-                        return '-';
+                        return sprintf(
+                            '%s - %s',
+                            $finalRating['ratingAvg'],
+                            $finalRating['performanceScale']
+                        );
                     }
+
+                    return '--';
                 }),
 
             Column::make(__('Period'))
-                ->label(function ($row) {
-                    if (is_null($row->performancesAsRegular->first())) {
-                        return ' - ';
-                    } else {
-                        return $row->performancesAsRegular->first()->period->interval;
-                    }
+                ->label(function () {
+                    $period = array_filter(
+                        $this->periodOptions,
+                        fn ($option) => $option == $this->period
+                            ? $this->periodOptions[$option]
+                            : null, 
+                        ARRAY_FILTER_USE_KEY
+                    );
+
+                    return $period ? array_values($period)[0] : '--';
                 }),
         ];
     }
@@ -200,32 +191,71 @@ class RegularSubordinatesPerformancesTable extends DataTableComponent
     public function filters(): array
     {
         return [
-            SelectFilter::make(__('Evaluation Period'))
-                ->options($this->getPeriodOptions())
+            SelectFilter::make(__('Evaluation Period'), 'evalPeriod')
+                ->options($this->periodOptions)
                 ->filter(function (Builder $query, $value) {
-                    return $query->whereHas('performancesAsRegular.period', function ($subQuery) use ($value) {
-                        $subQuery->where('period_id', $value);
+                    $query->where(function ($sq) use ($value) {
+                        $sq->whereHas('performancesAsRegular', 
+                            fn ($ssq) => $ssq->where('period_id', $value)
+                                            ->orWhereNot('period_id', $value)
+                        )->orWhereDoesntHave('performancesAsRegular');                        
+                    });
+
+                    $this->period = (int) $value;
+                })
+                ->notResetByClearButton()
+                ->setFilterPillTitle('Period')
+                ->setFilterDefaultValue(array_key_first($this->periodOptions))
+                ->hiddenFromMenus(),
+
+            SelectFilter::make(__('Completion'))
+                ->options([
+                    '' => __('Select Completion Status'),
+                    '0' => __('Incomplete'),
+                    '1' => __('Completed'),
+                ])
+                ->filter(function (Builder $query, $value) {
+                    if ($value === '0') {
+                        $query->whereDoesntHave(
+                            'performancesAsRegular', 
+                            fn ($sq) => $sq->where('period_id', $this->period)
+                        );
+                    } elseif ($value === '1') {
+                        $query->whereHas(
+                            'performancesAsRegular', 
+                            fn ($sq) => $sq->where('period_id', $this->period)
+                        );                        
+                    }
+                })
+                ->setFilterDefaultValue(''),
+
+            SelectFilter::make(__('Approval'))
+                ->options([
+                    '' => __('Select Approval Status'),
+                    '0' => __('Pending'),
+                    '1' => __('Approved'),
+                ])
+                ->filter(function (Builder $query, $value) {
+                    $query->whereHas('performancesAsRegular', function ($sq) use ($value) {
+                        $sq->where('period_id', $this->period);
+                        
+                        if ($value === '0') {
+                            $sq->whereNull('fourth_approver_signed_at');
+                        } elseif ($value === '1') {
+                            $sq->whereNotNull('fourth_approver_signed_at');
+                        }
                     });
                 })
-                ->setFilterPillTitle('Period')
-                // ->setFilterDefaultValue(RegularPerformancePeriod::latest()->first()->period_id)
+                ->setFilterDefaultValue(''),
         ];
-    }
-
-    private function periodDefaultValue()
-    {
-        // $query->whereBetween('end_date', [Carbon::parse(now())->startOfYear(), now()]);
     }
 
     private function getPeriodOptions(): array
     {
-        return RegularPerformancePeriod::all()
-            ->mapWithKeys(function ($item) {
-                $start = Carbon::make($item->start_date)->format('j M, Y');
-                $end = Carbon::make($item->end_date)->format('j M Y');
-                $period = "{$start} - {$end}";
-
-                return [$item->period_id => $period];
+        return RegularPerformancePeriod::orderByDesc('start_date')
+            ->get()
+            ->mapWithKeys(function ($period) {
+                return [$period->period_id => $period->interval];
             })->toArray();
     }
 }

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\CivilStatus;
+use BackedEnum;
 use Illuminate\Support\Str;
 use App\Enums\ActivityLogName;
 use Illuminate\Support\Carbon;
@@ -230,6 +231,18 @@ class Employee extends Model
                 Status::RETIRED->label(),
             ])
         );
+    }
+
+    /**
+     * Dynamic local scope to get employees of any type of employment status.
+     */
+    public function scopeOfEmploymentStatus(Builder $query, BackedEnum|string $employmentStatus): void
+    {
+        if ($employmentStatus instanceOf Status) {
+            $employmentStatus = $employmentStatus->label();
+        }
+
+        $query->whereHas('status', fn ($subQuery) => $subQuery->where('emp_status_name', $employmentStatus));
     }
 
     /**

--- a/app/Models/ProbationaryPerformance.php
+++ b/app/Models/ProbationaryPerformance.php
@@ -19,6 +19,14 @@ class ProbationaryPerformance extends Model
         'probationary_performance_id',
     ];
 
+    protected $casts = [
+        'evaluatee_signed_at'           => 'datetime',
+        'evaluator_signed_at'           => 'datetime',
+        'secondary_approver_signed_at'  => 'datetime',
+        'third_approver_signed_at'      => 'datetime',
+        'fourth_approver_signed_at'     => 'datetime',
+    ];
+
     /**
      * Get the performance period whe the performance evaluation occured.
      */

--- a/app/Models/ProbationaryPerformancePeriod.php
+++ b/app/Models/ProbationaryPerformancePeriod.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -23,13 +22,20 @@ class ProbationaryPerformancePeriod extends Model
         'end_date',
     ];
 
+    protected $casts = [
+        'start_date'    => 'datetime',
+        'end_date'      => 'datetime',
+        'created_at'    => 'datetime',
+        'updated_at'    => 'datetime,'
+    ];
+
     /**
      * Formatted attribute accessor for period interval (e.g: December 01 - December 12, 2025).
      */
     public function getIntervalAttribute()
     {
-        $start = Carbon::make($this->start_date)->format('F d');
-        $end = Carbon::make($this->end_date)->format('F d, Y');
+        $start = $this->start_date->format('F d');
+        $end = $this->end_date->format('F d, Y');
 
         return "{$start} - {$end}";
     }

--- a/app/Models/RegularPerformance.php
+++ b/app/Models/RegularPerformance.php
@@ -25,13 +25,13 @@ class RegularPerformance extends Model
     {
         $key = config('cache.keys.performance.ratings');
 
-        $cachedValue = Cache::rememberForever($key, function () {
-            return PerformanceRating::all();
-        });
+        $cachedValue = Cache::rememberForever($key, fn () => PerformanceRating::all());
 
-        $this->loadMissing([
-            'categoryRatings.rating',
-        ]);
+        if (! $cachedValue) {
+            $this->loadMissing([
+                'categoryRatings.rating',
+            ]);   
+        }
 
         $total = $this->categoryRatings->average(function ($item) {
             return $item->rating->perf_rating;

--- a/app/Models/RegularPerformancePeriod.php
+++ b/app/Models/RegularPerformancePeriod.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -21,13 +20,20 @@ class RegularPerformancePeriod extends Model
         'end_date',
     ];
 
+    protected $casts = [
+        'start_date'    => 'datetime',
+        'end_date'      => 'datetime',
+        'created_at'    => 'datetime',
+        'updated_at'    => 'datetime',
+    ];
+
     /**
      * Formatted attribute accessor for period interval (e.g: December 01 - December 12, 2025).
      */
     public function getIntervalAttribute()
     {
-        $start = Carbon::make($this->start_date)->format('F d');
-        $end = Carbon::make($this->end_date)->format('F d, Y');
+        $start = $this->start_date->format('F d');
+        $end = $this->end_date->format('F d, Y');
 
         return "{$start} - {$end}";
     }

--- a/app/Policies/RegularPerformancePolicy.php
+++ b/app/Policies/RegularPerformancePolicy.php
@@ -65,7 +65,7 @@ class RegularPerformancePolicy
         }
 
         if (! $this->isEvaluationPeriodOpen()) {
-            return Response::deny();
+            return Response::deny(__('Regular performance evaluation period is not open yet for this period'));
         }
 
         if (! $this->isEmployeeUnderJurisdiction($user, $employee)) {

--- a/database/seeders/FifthMonthEvaluationSeeder.php
+++ b/database/seeders/FifthMonthEvaluationSeeder.php
@@ -15,25 +15,23 @@ class FifthMonthEvaluationSeeder extends Seeder
      */
     public function run(): void
     {
-        $start = now();
-        $end = fake()->dateTimeBetween($start, (clone $start)->modify('+10 days'));
+        $start = now()->subDays(3);
+        $end = $start->copy()->addWeeks(2);
 
-        $probationaries = Employee::whereHas('status', function ($query) {
-            $query->where('emp_status_name', EmploymentStatus::PROBATIONARY->label());
-        })->get();
+        $probationaries = Employee::ofEmploymentStatus(EmploymentStatus::PROBATIONARY)->get();
 
         $data = [];
 
         $probationaries->each(function ($item) 
             use (&$data, $start, $end) {
-                array_push($data, [
+                $data[] = [
                     'evaluatee' => $item->employee_id,
                     'period_name' => PerformanceEvaluationPeriod::FIFTH_MONTH,
                     'start_date' => $start,
                     'end_date' => $end,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
+                    'created_at' => $start,
+                    'updated_at' => $start,
+                ];
             }
         );
 

--- a/database/seeders/FinalMonthEvaluationSeeder.php
+++ b/database/seeders/FinalMonthEvaluationSeeder.php
@@ -16,11 +16,9 @@ class FinalMonthEvaluationSeeder extends Seeder
     public function run(): void
     {
         $start = now();
-        $end = fake()->dateTimeBetween($start, (clone $start)->modify('+10 days'));
+        $end = $start->copy()->addWeeks(2);
 
-        $probationaries = Employee::whereHas('status', function ($query) {
-            $query->where('emp_status_name', EmploymentStatus::PROBATIONARY->label());
-        })->get();
+        $probationaries = Employee::ofEmploymentStatus(EmploymentStatus::PROBATIONARY)->get();
 
         $data = [];
 
@@ -31,8 +29,8 @@ class FinalMonthEvaluationSeeder extends Seeder
                     'period_name' => PerformanceEvaluationPeriod::FINAL_MONTH,
                     'start_date' => $start,
                     'end_date' => $end,
-                    'created_at' => now(),
-                    'updated_at' => now(),
+                    'created_at' => $start,
+                    'updated_at' => $start,
                 ]);
             }
         );

--- a/database/seeders/ThirdMonthEvaluationSeeder.php
+++ b/database/seeders/ThirdMonthEvaluationSeeder.php
@@ -15,27 +15,23 @@ class ThirdMonthEvaluationSeeder extends Seeder
      */
     public function run(): void
     {
-        $start = now();
-        $end = fake()->dateTimeBetween($start, (clone $start)->modify('+10 days'));
-
-        $probationaries = Employee::whereHas('status', function ($query) {
-            $query->where('emp_status_name', EmploymentStatus::PROBATIONARY->label());
-        })->get();
+        $probationaries = Employee::ofEmploymentStatus(EmploymentStatus::PROBATIONARY)->get();
 
         $data = [];
 
-        $probationaries->each(function ($item) 
-            use (&$data, $start, $end) {
-                array_push($data, [
-                    'evaluatee' => $item->employee_id,
-                    'period_name' => PerformanceEvaluationPeriod::THIRD_MONTH,
-                    'start_date' => $start,
-                    'end_date' => $end,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-            }
-        );
+        $start = now()->subWeek();
+        $end = $start->copy()->addWeeks(2);
+
+        $probationaries->each(function ($proby) use (&$data, $start, $end) {
+            $data[] = [
+                'evaluatee' => $proby->employee_id,
+                'period_name' => PerformanceEvaluationPeriod::THIRD_MONTH->value,
+                'start_date' => $start,
+                'end_date' => $end,
+                'created_at' => $start,
+                'updated_at' => $start,
+            ];
+        });
 
         DB::table('probationary_performance_periods')->insert($data);
     }

--- a/resources/views/components/table/employee.blade.php
+++ b/resources/views/components/table/employee.blade.php
@@ -1,0 +1,15 @@
+@props([
+    'name' => __('Unknown Employee'),
+    'photo' => null,
+    'id' => null,
+])
+
+<div class="d-flex align-items-center">
+    <img src="{{ $photo }}" alt="{{ "{$name}-avatar" }}" class="rounded-circle me-3" style="width: 38px; height: 38px">
+    <div>
+        <div> {{ $name }} </div>
+        <div class="text-muted fs-6">
+            {{ __("Employee No. {$id}") }}
+        </div>
+    </div>
+</div>

--- a/resources/views/employee/hr-manager/evaluations/probationary/all.blade.php
+++ b/resources/views/employee/hr-manager/evaluations/probationary/all.blade.php
@@ -1,12 +1,10 @@
 @extends('components.layout.employee.layout', ['description' => 'Probationaries Performance Evaluation', 'nonce' => $nonce])
-@use ('Illuminate\View\ComponentAttributeBag')
 
 @section('head')
-<title>Probationary Employees | Performance Evaluation</title>
+<title>Performance Evaluation • Probationaries</title>
 <script rel="preload" as="script" type="text/js" src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 <script src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 @endsection
-
 
 @pushOnce('scripts')
     @vite(['resources/js/employee/hr-manager/performance.js'])
@@ -20,7 +18,7 @@
 
 <x-headings.main-heading :isHeading="true">
     <x-slot:heading>
-        {{ __('Probationaries Performance Evaluation Table') }}
+        {{ __('Performance Evaluations • Probationaries') }}
     </x-slot:heading>
 
     <x-slot:description>

--- a/resources/views/employee/hr-manager/evaluations/regular/all.blade.php
+++ b/resources/views/employee/hr-manager/evaluations/regular/all.blade.php
@@ -1,7 +1,7 @@
 @extends('components.layout.employee.layout', ['description' => 'Regulars Performance Evaluation', 'nonce' => $nonce])
 
 @section('head')
-<title>Regular Employees | Performance Evaluation</title>
+<title>Performance Evaluation • Regulars</title>
 <script rel="preload" as="script" type="text/js" src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 <script src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 @endsection
@@ -22,7 +22,7 @@
 
 <x-headings.main-heading :isHeading="true">
     <x-slot:heading>
-        {{ __('Regulars Performance Evaluation Table') }}
+        {{ __('Performance Evaluations • Regulars') }}
     </x-slot:heading>
 
     <x-slot:description>

--- a/resources/views/employee/supervisor/performance-evaluations/probationaries/all.blade.php
+++ b/resources/views/employee/supervisor/performance-evaluations/probationaries/all.blade.php
@@ -1,7 +1,9 @@
 @extends('components.layout.employee.layout', ['description' => 'Probationary Subordinates Performance Evaluations', 'nonce' => $nonce])
 
+@php $jobFamily = auth()->user()->account->jobTitle->jobFamily->job_family_name; @endphp
+
 @section('head')
-<title>Probationaries Performance Evaluations</title>
+<title>Performance Evaluations • {{ $jobFamily }}'s Probationaries</title>
 <script rel="preload" as="script" type="text/js" src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 <script src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 @endsection
@@ -18,15 +20,14 @@
 
 <x-headings.main-heading :isHeading="true">
     <x-slot:heading>
-        {{ __('Probationaries Performance Evaluation') }}
+        {!! sprintf(
+            "%s • <span class='text-primary'>%s</span> %s", 
+            'Performance Evaluations', $jobFamily, 'Probationaries'
+        ) !!}
     </x-slot:heading>
 
     <x-slot:description>
-        {!! __('View and manage '.
-        '<span class="text-primary fw-semibold">'
-            .auth()->user()->account->jobTitle->jobFamily->job_family_name.
-        '</span>'.
-        '\'s probationaries performances here. Incomplete status will redirect you to the performance evaluation form.') !!}
+        {{ __('Incomplete status will redirect you to the performance evaluation form.') }}
     </x-slot:description>
 </x-headings.main-heading>
 

--- a/resources/views/employee/supervisor/performance-evaluations/regulars/all.blade.php
+++ b/resources/views/employee/supervisor/performance-evaluations/regulars/all.blade.php
@@ -1,7 +1,9 @@
 @extends('components.layout.employee.layout', ['description' => 'Regular Subordinates Performance Evaluations', 'nonce' => $nonce])
 
+@php $jobFamily = auth()->user()->account->jobTitle->jobFamily->job_family_name; @endphp
+
 @section('head')
-<title>Regulars Performance Evaluations</title>
+<title>Performance Evaluations • {{ $jobFamily }}'s Regulars</title>
 <script rel="preload" as="script" type="text/js" src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 <script src="https://unpkg.com/lucide@0.428.0/dist/umd/lucide.min.js"></script>
 @endsection
@@ -18,15 +20,14 @@
 
 <x-headings.main-heading :isHeading="true">
     <x-slot:heading>
-        {{ __('Regulars Performance Evaluation') }}
+        {!! sprintf(
+            "%s • <span class='text-primary'>%s</span> %s", 
+            'Performance Evaluations', $jobFamily, 'Regulars'
+        ) !!}
     </x-slot:heading>
 
     <x-slot:description>
-        {!! __('View and manage '.
-        '<span class="text-primary fw-semibold">'
-            .auth()->user()->account->jobTitle->jobFamily->job_family_name.
-        '</span>'.
-        '\'s regulars performances here. Incomplete status will redirect you to the performance evaluation form.') !!}
+        {{ __('Incomplete status will redirect you to the performance evaluation form.') }}
     </x-slot:description>
 </x-headings.main-heading>
 


### PR DESCRIPTION
### 🛠 Changes

- **Fixed routing issue of regular employees' peformance evaluation table won't redirect to create form if already filled-out from prior year/s**
- Improved table header labels.
- Replaced clickable rows with CTA buttons.
- Added additional filters both probationaries and regulars.

### 📸 Screenshots

![image](https://github.com/user-attachments/assets/4e7b9252-65ad-46ea-b6b1-b7d86a61e39c)


### ✔️ Checklist

- [x] Is `staging` the base branch of this PR?
- [x] Do your changes not reveal sensitive information, such as secrets, API keys, etc?
- [x] Are there no erroneous console logs, debuggers, or leftover code in your changes?
